### PR TITLE
829 optimize testingstrategy

### DIFF
--- a/cpp/examples/abm_minimal.cpp
+++ b/cpp/examples/abm_minimal.cpp
@@ -41,9 +41,12 @@ int main()
     world.parameters.get<mio::abm::IncubationPeriod>() = 4.;
 
     // Set the age group the can go to school is AgeGroup(1) (i.e. 5-14)
-    world.parameters.get<mio::abm::AgeGroupGotoSchool>() = {age_group_5_to_14};
+    world.parameters.get<mio::abm::AgeGroupGotoSchool>() = false;
+    world.parameters.get<mio::abm::AgeGroupGotoSchool>()[age_group_5_to_14] = true;
     // Set the age group the can go to work is AgeGroup(2) and AgeGroup(3) (i.e. 15-34 and 35-59)
-    world.parameters.get<mio::abm::AgeGroupGotoWork>() = {age_group_15_to_34, age_group_35_to_59};
+    world.parameters.get<mio::abm::AgeGroupGotoWork>() = false;
+    world.parameters.get<mio::abm::AgeGroupGotoWork>()[age_group_15_to_34] = true;
+    world.parameters.get<mio::abm::AgeGroupGotoWork>()[age_group_35_to_59] = true;
 
     // Check if the parameters satisfy their contraints.
     world.parameters.check_constraints();

--- a/cpp/models/abm/config.h
+++ b/cpp/models/abm/config.h
@@ -1,0 +1,36 @@
+/*
+* Copyright (C) 2020-2024 MEmilio
+*
+* Authors: Daniel Abele
+*
+* Contact: Martin J. Kuehn <Martin.Kuehn@DLR.de>
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+#ifndef MIO_ABM_CONFIG_H
+#define MIO_ABM_CONFIG_H
+
+namespace mio
+{
+namespace abm
+{
+
+/**
+ * Maximum number of age groups allowed in the model.
+ */
+const constexpr int MAX_NUM_AGE_GROUPS = 64;
+
+}
+} // namespace mio
+
+#endif

--- a/cpp/models/abm/migration_rules.cpp
+++ b/cpp/models/abm/migration_rules.cpp
@@ -56,7 +56,7 @@ LocationType go_to_school(Person::RandomNumberGenerator& /*rng*/, const Person& 
     if (current_loc == LocationType::Home && t < params.get<LockdownDate>() && t.day_of_week() < 5 &&
         person.get_go_to_school_time(params) >= t.time_since_midnight() &&
         person.get_go_to_school_time(params) < t.time_since_midnight() + dt &&
-        params.get<mio::abm::AgeGroupGotoSchool>().count(person.get_age()) && person.goes_to_school(t, params) &&
+        params.get<mio::abm::AgeGroupGotoSchool>()[person.get_age()] && person.goes_to_school(t, params) &&
         !person.is_in_quarantine()) {
         return LocationType::School;
     }
@@ -73,7 +73,7 @@ LocationType go_to_work(Person::RandomNumberGenerator& /*rng*/, const Person& pe
     auto current_loc = person.get_location().get_type();
 
     if (current_loc == LocationType::Home && t < params.get<LockdownDate>() &&
-        params.get<mio::abm::AgeGroupGotoWork>().count(person.get_age()) && t.day_of_week() < 5 &&
+        params.get<mio::abm::AgeGroupGotoWork>()[person.get_age()] && t.day_of_week() < 5 &&
         t.time_since_midnight() + dt > person.get_go_to_work_time(params) &&
         t.time_since_midnight() <= person.get_go_to_work_time(params) && person.goes_to_work(t, params) &&
         !person.is_in_quarantine()) {

--- a/cpp/models/abm/parameters.h
+++ b/cpp/models/abm/parameters.h
@@ -497,10 +497,12 @@ struct GotoSchoolTimeMaximum {
  * @brief The set of AgeGroups that can go to school.
  */
 struct AgeGroupGotoSchool {
-    using Type = std::set<AgeGroup>;
-    static Type get_default(AgeGroup /*size*/)
+    using Type = CustomIndexArray<bool, AgeGroup>;
+    static Type get_default(AgeGroup num_agegroups)
     {
-        return std::set<AgeGroup>{AgeGroup(1)};
+        auto a = Type(num_agegroups, false);
+        a[AgeGroup(1)] = true;
+        return a;
     }
     static std::string name()
     {
@@ -512,10 +514,13 @@ struct AgeGroupGotoSchool {
  * @brief The set of AgeGroups that can go to work.
  */
 struct AgeGroupGotoWork {
-    using Type = std::set<AgeGroup>;
-    static Type get_default(AgeGroup /*size*/)
+    using Type = CustomIndexArray<bool, AgeGroup>;
+    static Type get_default(AgeGroup num_agegroups)
     {
-        return std::set<AgeGroup>{AgeGroup(2), AgeGroup(3)};
+        auto a = Type(num_agegroups, false);
+        a[AgeGroup(2)] = true;
+        a[AgeGroup(3)] = true;
+        return a;
     }
     static std::string name()
     {

--- a/cpp/models/abm/testing_strategy.cpp
+++ b/cpp/models/abm/testing_strategy.cpp
@@ -29,7 +29,7 @@ namespace abm
 TestingCriteria::TestingCriteria(const std::vector<AgeGroup>& ages, const std::vector<InfectionState>& infection_states)
 {
     for (auto age : ages) {
-        m_ages.insert(static_cast<size_t>(age));
+        m_ages.set(static_cast<size_t>(age), true);
     }
     for (auto infection_state : infection_states) {
         m_infection_states.set(static_cast<size_t>(infection_state), true);
@@ -43,12 +43,12 @@ bool TestingCriteria::operator==(const TestingCriteria& other) const
 
 void TestingCriteria::add_age_group(const AgeGroup age_group)
 {
-    m_ages.insert(static_cast<size_t>(age_group));
+    m_ages.set(static_cast<size_t>(age_group), true);
 }
 
 void TestingCriteria::remove_age_group(const AgeGroup age_group)
 {
-    m_ages.erase(static_cast<size_t>(age_group));
+    m_ages.set(static_cast<size_t>(age_group), false);
 }
 
 void TestingCriteria::add_infection_state(const InfectionState infection_state)
@@ -64,7 +64,7 @@ void TestingCriteria::remove_infection_state(const InfectionState infection_stat
 bool TestingCriteria::evaluate(const Person& p, TimePoint t) const
 {
     // An empty vector of ages or none bitset of #InfectionStates% means that no condition on the corresponding property is set. 
-    return (m_ages.empty() || m_ages.count(static_cast<size_t>(p.get_age()))) &&
+    return (m_ages.none() || m_ages[static_cast<size_t>(p.get_age())]) &&
            (m_infection_states.none() || m_infection_states[static_cast<size_t>(p.get_infection_state(t))]);
 }
 

--- a/cpp/models/abm/testing_strategy.cpp
+++ b/cpp/models/abm/testing_strategy.cpp
@@ -103,9 +103,9 @@ void TestingScheme::update_activity_status(TimePoint t)
 bool TestingScheme::run_scheme(Person::RandomNumberGenerator& rng, Person& person, TimePoint t) const
 {
     if (person.get_time_since_negative_test() > m_minimal_time_since_last_test) {
-        double random = UniformDistribution<double>::get_instance()(rng);
-        if (random < m_probability) {
-            if (m_testing_criteria.evaluate(person, t)) {
+        if (m_testing_criteria.evaluate(person, t)) {
+            double random = UniformDistribution<double>::get_instance()(rng);
+            if (random < m_probability) {
                 return !person.get_tested(rng, t, m_test_type.get_default());
             }
         }

--- a/cpp/models/abm/testing_strategy.h
+++ b/cpp/models/abm/testing_strategy.h
@@ -221,7 +221,7 @@ public:
     bool run_strategy(Person::RandomNumberGenerator& rng, Person& person, const Location& location, TimePoint t);
 
 private:
-    std::unordered_map<LocationId, std::vector<TestingScheme>>
+    std::vector<std::pair<LocationId, std::vector<TestingScheme>>>
         m_location_to_schemes_map; ///< Set of schemes that are checked for testing.
 };
 

--- a/cpp/models/abm/testing_strategy.h
+++ b/cpp/models/abm/testing_strategy.h
@@ -20,6 +20,7 @@
 #ifndef EPI_ABM_TESTING_SCHEME_H
 #define EPI_ABM_TESTING_SCHEME_H
 
+#include "abm/config.h"
 #include "abm/parameters.h"
 #include "abm/person.h"
 #include "abm/location.h"
@@ -91,7 +92,7 @@ public:
     bool evaluate(const Person& p, TimePoint t) const;
 
 private:
-    std::unordered_set<size_t> m_ages; ///< Set of #AgeGroup%s that are either allowed or required to be tested.
+    std::bitset<MAX_NUM_AGE_GROUPS> m_ages; ///< Set of #AgeGroup%s that are either allowed or required to be tested.
     std::bitset<(size_t)InfectionState::Count>
         m_infection_states; /**< BitSet of #InfectionState%s that are either allowed or required to
     be tested.*/

--- a/cpp/models/abm/world.h
+++ b/cpp/models/abm/world.h
@@ -20,6 +20,7 @@
 #ifndef EPI_ABM_WORLD_H
 #define EPI_ABM_WORLD_H
 
+#include "abm/config.h"
 #include "abm/location_type.h"
 #include "abm/parameters.h"
 #include "abm/location.h"
@@ -55,7 +56,7 @@ public:
 
     /**
      * @brief Create a World.
-     * @param[in] num_agegroups The number of AgeGroup%s in the simulated World.
+     * @param[in] num_agegroups The number of AgeGroup%s in the simulated World. Must be less than MAX_NUM_AGE_GROUPS.
      */
     World(size_t num_agegroups)
         : parameters(num_agegroups)
@@ -63,6 +64,7 @@ public:
         , m_use_migration_rules(true)
         , m_cemetery_id(add_location(LocationType::Cemetery))
     {
+        assert(num_agegroups < MAX_NUM_AGE_GROUPS && "MAX_NUM_AGE_GROUPS exceeded.");
     }
 
     /**

--- a/cpp/tests/test_abm_lockdown_rules.cpp
+++ b/cpp/tests/test_abm_lockdown_rules.cpp
@@ -53,9 +53,12 @@ TEST(TestLockdownRules, school_closure)
     p2.set_assigned_location(school);
     mio::abm::Parameters params = mio::abm::Parameters(NUM_AGE_GROUPS);
     // Set the age group the can go to school is AgeGroup(1) (i.e. 5-14)
-    params.get<mio::abm::AgeGroupGotoSchool>() = {AGE_GROUP_5_TO_14};
+    params.get<mio::abm::AgeGroupGotoSchool>() = false;
+    params.get<mio::abm::AgeGroupGotoSchool>()[AGE_GROUP_5_TO_14] = true;
     // Set the age group the can go to work is AgeGroup(2) and AgeGroup(3) (i.e. 15-34 or 35-59)
-    params.get<mio::abm::AgeGroupGotoWork>() = {AGE_GROUP_15_TO_34, AGE_GROUP_35_TO_59};
+    params.get<mio::abm::AgeGroupGotoWork>() = false;
+    params.get<mio::abm::AgeGroupGotoWork>()[AGE_GROUP_15_TO_34] = true;
+    params.get<mio::abm::AgeGroupGotoWork>()[AGE_GROUP_35_TO_59] = true;
     mio::abm::set_school_closure(t, 0.7, params);
 
     auto p1_rng = mio::abm::Person::RandomNumberGenerator(rng, p1);
@@ -88,9 +91,12 @@ TEST(TestLockdownRules, school_opening)
     p.set_assigned_location(school);
     mio::abm::Parameters params = mio::abm::Parameters(NUM_AGE_GROUPS);
     // Set the age group the can go to school is AgeGroup(1) (i.e. 5-14)
-    params.get<mio::abm::AgeGroupGotoSchool>() = {AGE_GROUP_5_TO_14};
+    params.get<mio::abm::AgeGroupGotoSchool>() = false;
+    params.get<mio::abm::AgeGroupGotoSchool>()[AGE_GROUP_5_TO_14] = true;
     // Set the age group the can go to work is AgeGroup(2) and AgeGroup(3) (i.e. 15-34 or 35-59)
-    params.get<mio::abm::AgeGroupGotoWork>() = {AGE_GROUP_15_TO_34, AGE_GROUP_35_TO_59};
+    params.get<mio::abm::AgeGroupGotoWork>() = false;
+    params.get<mio::abm::AgeGroupGotoWork>()[AGE_GROUP_15_TO_34] = true;
+    params.get<mio::abm::AgeGroupGotoWork>()[AGE_GROUP_35_TO_59] = true;
     mio::abm::set_school_closure(t_closing, 1., params);
     mio::abm::set_school_closure(t_opening, 0., params);
 
@@ -110,9 +116,12 @@ TEST(TestLockdownRules, home_office)
     mio::abm::Parameters params(NUM_AGE_GROUPS);
 
     // Set the age group the can go to school is AgeGroup(1) (i.e. 5-14)
-    params.get<mio::abm::AgeGroupGotoSchool>() = {AGE_GROUP_5_TO_14};
+    params.get<mio::abm::AgeGroupGotoSchool>() = false;
+    params.get<mio::abm::AgeGroupGotoSchool>()[AGE_GROUP_5_TO_14] = true;
     // Set the age group the can go to work is AgeGroup(2) and AgeGroup(3) (i.e. 15-34 or 35-59)
-    params.get<mio::abm::AgeGroupGotoWork>() = {AGE_GROUP_15_TO_34, AGE_GROUP_35_TO_59};
+    params.get<mio::abm::AgeGroupGotoWork>() = false;
+    params.get<mio::abm::AgeGroupGotoWork>()[AGE_GROUP_15_TO_34] = true;
+    params.get<mio::abm::AgeGroupGotoWork>()[AGE_GROUP_35_TO_59] = true;
 
     mio::abm::set_home_office(t, 0.4, params);
 
@@ -164,9 +173,12 @@ TEST(TestLockdownRules, no_home_office)
     p.set_assigned_location(work);
     mio::abm::Parameters params = mio::abm::Parameters(NUM_AGE_GROUPS);
     // Set the age group the can go to school is AgeGroup(1) (i.e. 5-14)
-    params.get<mio::abm::AgeGroupGotoSchool>() = {AGE_GROUP_5_TO_14};
+    params.get<mio::abm::AgeGroupGotoSchool>() = false;
+    params.get<mio::abm::AgeGroupGotoSchool>()[AGE_GROUP_5_TO_14] = true;
     // Set the age group the can go to work is AgeGroup(2) and AgeGroup(3) (i.e. 15-34 or 35-59)
-    params.get<mio::abm::AgeGroupGotoWork>() = {AGE_GROUP_15_TO_34, AGE_GROUP_35_TO_59};
+    params.get<mio::abm::AgeGroupGotoWork>() = false;
+    params.get<mio::abm::AgeGroupGotoWork>()[AGE_GROUP_15_TO_34] = true;
+    params.get<mio::abm::AgeGroupGotoWork>()[AGE_GROUP_35_TO_59] = true;
 
     mio::abm::set_home_office(t_closing, 0.5, params);
     mio::abm::set_home_office(t_opening, 0., params);

--- a/cpp/tests/test_abm_migration_rules.cpp
+++ b/cpp/tests/test_abm_migration_rules.cpp
@@ -44,9 +44,12 @@ TEST(TestMigrationRules, student_goes_to_school)
     auto child_rng              = mio::abm::Person::RandomNumberGenerator(rng, p_child);
     auto adult_rng              = mio::abm::Person::RandomNumberGenerator(rng, p_child);
     // Set the age group the can go to school is AgeGroup(1) (i.e. 5-14)
-    params.get<mio::abm::AgeGroupGotoSchool>() = {AGE_GROUP_5_TO_14};
+    params.get<mio::abm::AgeGroupGotoSchool>() = false;
+    params.get<mio::abm::AgeGroupGotoSchool>()[AGE_GROUP_5_TO_14] = true;
     // Set the age group the can go to work is AgeGroup(2) and AgeGroup(3) (i.e. 15-34 or 35-59)
-    params.get<mio::abm::AgeGroupGotoWork>() = {AGE_GROUP_15_TO_34, AGE_GROUP_35_TO_59};
+    params.get<mio::abm::AgeGroupGotoWork>() = false;
+    params.get<mio::abm::AgeGroupGotoWork>()[AGE_GROUP_15_TO_34] = true;
+    params.get<mio::abm::AgeGroupGotoWork>()[AGE_GROUP_35_TO_59] = true;
 
     ASSERT_EQ(mio::abm::go_to_school(child_rng, p_child, t_morning, dt, params), mio::abm::LocationType::School);
     ASSERT_EQ(mio::abm::go_to_school(adult_rng, p_adult, t_morning, dt, params), mio::abm::LocationType::Home);
@@ -85,9 +88,12 @@ TEST(TestMigrationRules, students_go_to_school_in_different_times)
 
     mio::abm::Parameters params = mio::abm::Parameters(NUM_AGE_GROUPS);
     // Set the age group the can go to school is AgeGroup(1) (i.e. 5-14)
-    params.get<mio::abm::AgeGroupGotoSchool>() = {AGE_GROUP_5_TO_14};
+    params.get<mio::abm::AgeGroupGotoSchool>() = false;
+    params.get<mio::abm::AgeGroupGotoSchool>()[AGE_GROUP_5_TO_14] = true;
     // Set the age group the can go to work is AgeGroup(2) and AgeGroup(3) (i.e. 15-34 or 35-59)
-    params.get<mio::abm::AgeGroupGotoWork>() = {AGE_GROUP_15_TO_34, AGE_GROUP_35_TO_59};
+    params.get<mio::abm::AgeGroupGotoWork>() = false;
+    params.get<mio::abm::AgeGroupGotoWork>()[AGE_GROUP_15_TO_34] = true;
+    params.get<mio::abm::AgeGroupGotoWork>()[AGE_GROUP_35_TO_59] = true;
 
     ASSERT_EQ(
         mio::abm::go_to_school(rng_child_goes_to_school_at_6, p_child_goes_to_school_at_6, t_morning_6, dt, params),
@@ -142,9 +148,12 @@ TEST(TestMigrationRules, students_go_to_school_in_different_times_with_smaller_t
     auto dt                     = mio::abm::seconds(1800);
     mio::abm::Parameters params = mio::abm::Parameters(NUM_AGE_GROUPS);
     // Set the age group the can go to school is AgeGroup(1) (i.e. 5-14)
-    params.get<mio::abm::AgeGroupGotoSchool>() = {AGE_GROUP_5_TO_14};
+    params.get<mio::abm::AgeGroupGotoSchool>() = false;
+    params.get<mio::abm::AgeGroupGotoSchool>()[AGE_GROUP_5_TO_14] = true;
     // Set the age group the can go to work is AgeGroup(2) and AgeGroup(3) (i.e. 15-34 or 35-59)
-    params.get<mio::abm::AgeGroupGotoWork>() = {AGE_GROUP_15_TO_34, AGE_GROUP_35_TO_59};
+    params.get<mio::abm::AgeGroupGotoWork>() = false;
+    params.get<mio::abm::AgeGroupGotoWork>()[AGE_GROUP_15_TO_34] = true;
+    params.get<mio::abm::AgeGroupGotoWork>()[AGE_GROUP_35_TO_59] = true;
 
     ASSERT_EQ(
         mio::abm::go_to_school(rng_child_goes_to_school_at_6, p_child_goes_to_school_at_6, t_morning_6, dt, params),
@@ -203,9 +212,12 @@ TEST(TestMigrationRules, worker_goes_to_work)
 
     mio::abm::Parameters params = mio::abm::Parameters(NUM_AGE_GROUPS);
     // Set the age group the can go to school is AgeGroup(1) (i.e. 5-14)
-    params.get<mio::abm::AgeGroupGotoSchool>() = {AGE_GROUP_5_TO_14};
+    params.get<mio::abm::AgeGroupGotoSchool>() = false;
+    params.get<mio::abm::AgeGroupGotoSchool>()[AGE_GROUP_5_TO_14] = true;
     // Set the age group the can go to work is AgeGroup(2) and AgeGroup(3) (i.e. 15-34 or 35-59)
-    params.get<mio::abm::AgeGroupGotoWork>() = {AGE_GROUP_15_TO_34, AGE_GROUP_35_TO_59};
+    params.get<mio::abm::AgeGroupGotoWork>() = false;
+    params.get<mio::abm::AgeGroupGotoWork>()[AGE_GROUP_15_TO_34] = true;
+    params.get<mio::abm::AgeGroupGotoWork>()[AGE_GROUP_35_TO_59] = true;
 
     ASSERT_EQ(mio::abm::go_to_work(rng_retiree, p_retiree, t_morning, dt, params), mio::abm::LocationType::Home);
     ASSERT_EQ(mio::abm::go_to_work(rng_adult, p_adult, t_morning, dt, params), mio::abm::LocationType::Home);
@@ -240,9 +252,12 @@ TEST(TestMigrationRules, worker_goes_to_work_with_non_dividable_timespan)
 
     mio::abm::Parameters params = mio::abm::Parameters(NUM_AGE_GROUPS);
     // Set the age group the can go to school is AgeGroup(1) (i.e. 5-14)
-    params.get<mio::abm::AgeGroupGotoSchool>() = {AGE_GROUP_5_TO_14};
+    params.get<mio::abm::AgeGroupGotoSchool>() = false;
+    params.get<mio::abm::AgeGroupGotoSchool>()[AGE_GROUP_5_TO_14] = true;
     // Set the age group the can go to work is AgeGroup(2) and AgeGroup(3) (i.e. 15-34 or 35-59)
-    params.get<mio::abm::AgeGroupGotoWork>() = {AGE_GROUP_15_TO_34, AGE_GROUP_35_TO_59};
+    params.get<mio::abm::AgeGroupGotoWork>() = false;
+    params.get<mio::abm::AgeGroupGotoWork>()[AGE_GROUP_15_TO_34] = true;
+    params.get<mio::abm::AgeGroupGotoWork>()[AGE_GROUP_35_TO_59] = true;
 
     ASSERT_EQ(mio::abm::go_to_work(rng_retiree, p_retiree, t_morning, dt, params), mio::abm::LocationType::Home);
     ASSERT_EQ(mio::abm::go_to_work(rng_adult, p_adult, t_morning, dt, params), mio::abm::LocationType::Home);
@@ -278,9 +293,12 @@ TEST(TestMigrationRules, workers_go_to_work_in_different_times)
     auto dt                     = mio::abm::hours(1);
     mio::abm::Parameters params = mio::abm::Parameters(NUM_AGE_GROUPS);
     // Set the age group the can go to school is AgeGroup(1) (i.e. 5-14)
-    params.get<mio::abm::AgeGroupGotoSchool>() = {AGE_GROUP_5_TO_14};
+    params.get<mio::abm::AgeGroupGotoSchool>() = false;
+    params.get<mio::abm::AgeGroupGotoSchool>()[AGE_GROUP_5_TO_14] = true;
     // Set the age group the can go to work is AgeGroup(2) and AgeGroup(3) (i.e. 15-34 or 35-59)
-    params.get<mio::abm::AgeGroupGotoWork>() = {AGE_GROUP_15_TO_34, AGE_GROUP_35_TO_59};
+    params.get<mio::abm::AgeGroupGotoWork>() = false;
+    params.get<mio::abm::AgeGroupGotoWork>()[AGE_GROUP_15_TO_34] = true;
+    params.get<mio::abm::AgeGroupGotoWork>()[AGE_GROUP_35_TO_59] = true;
 
     ASSERT_EQ(mio::abm::go_to_work(rng_adult_goes_to_work_at_6, p_adult_goes_to_work_at_6, t_morning_6, dt, params),
               mio::abm::LocationType::Work);

--- a/cpp/tests/test_abm_testing_strategy.cpp
+++ b/cpp/tests/test_abm_testing_strategy.cpp
@@ -137,10 +137,9 @@ TEST(TestTestingScheme, initAndRunTestingStrategy)
 
     ScopedMockDistribution<testing::StrictMock<MockDistribution<mio::UniformDistribution<double>>>> mock_uniform_dist;
     EXPECT_CALL(mock_uniform_dist.get_mock(), invoke)
-        .Times(testing::Exactly(3))
+        .Times(testing::Exactly(2)) //only sampled twice, testing criteria don't apply to third person
         .WillOnce(testing::Return(0.7))
-        .WillOnce(testing::Return(0.5))
-        .WillOnce(testing::Return(0.9));
+        .WillOnce(testing::Return(0.5));
 
     mio::abm::TestingStrategy test_strategy =
         mio::abm::TestingStrategy(std::unordered_map<mio::abm::LocationId, std::vector<mio::abm::TestingScheme>>());


### PR DESCRIPTION
## Changes and Information

@khoanguyen-dev @xsaschako @DavidKerkmann 
These changes are not ready for review yet, at least some need to be discussed since they change the model, not just performance. I want to show the changes early as a basis for discussion.

Closes #829 
Closes #357 
Closes #857

### 1
use bitset for age groups in `TestingCriteria`; bitset needs a fixed size, so add a maximum number of age groups. performance gain is quite small (< 1-2%), so maybe not necessary if you feel the maximum number is not wanted.

### 2
switch the order of `if` for probabilty check and evaluating `TestingCriteria` when applying the test; again a very small performance gain (<5%) that also depends on the performance of the RNG and the complexity of `TestingCriteria`. if TestingCriteria might become more complex in the future we may want to skip this. This doesn't change the model in theory, but in practice it does since the sequence of random numbers changes.

### 3
use CustomIndexArray for AgeGroupGoToSchool/Work; the performance gain here is barely measureable. But the interface of CustomIndexArray is more consistent with the rest of the parameters; AgeGroup and the enums we use are valid indices for a reason, random access is fast and convenient using an index into an array.

### 4
use std::vector to store testingschemes per location instead of std::map; The performance gains here are very large (~20-30% of total benchmark runtime). The current implementation with map has two problems: 
    - lookups in map are more expensive than linear search in vectors for small numbers of elements; map is only better for quite large numbers. 
    - lookup in map with `operator[]` adds an element to the map if it doesn't exist. So the map quickly grows and has an entry for every location, making lookup even slower. This can be solved by using std::vector, but it can also be solved with a map by using `map::find` instead of `map::operator[]`, so it's at least somewhat independent from the first issue, but the implementation with vector is slightly faster, at least unless you add a lot of TestingSchemes for different locations

### 5
only run the TestingStrategy when migrating; this is the largest change to the model, but also the largest performance gain, ~30-50% (Note that these are not fully additive with the other improvements above, if the TestingStrategy is executed less often, the runtime of the TestingStrategy itself doesn't matter as much); Persons are tested much less, persons that never leave home are never tested at all, even if there is a TestingScheme for home locations; that may be realistic, but needs to be discussed. 

Another model could be to run tests only when migrating, but for the source location as well as the destination. This would give most of the performance benefits from this change with probably less impact on the model results (e.g. person leaves home to get to work, is tested at home and at work and stays home if either of them fails). 

If we expect a lot of TestingSchemes for specific single locations (instead of locationtypes) it might be better to store the testing scheme in the location directly.

## Merge Request - Guideline Checklist

Please check our [git workflow](https://github.com/DLR-SC/memilio/wiki/git-workflow). Use the **draft** feature if the Pull Request is not yet ready to review.

### Checks by code author

- [x] Every addressed issue is linked (use the "Closes #ISSUE" keyword below)
- [x] New code adheres to [coding guidelines](https://github.com/DLR-SC/memilio/wiki/Coding-guidelines)
- [x] No large data files have been added (files should in sum not exceed 100 KB, avoid PDFs, Word docs, etc.)
- [x] Tests are added for new functionality and a local test run was successful
- [x] Appropriate **documentation** for new functionality has been added (Doxygen in the code and Markdown files if necessary)
- [x] Proper attention to licenses, especially no new third-party software with conflicting license has been added

### Checks by code reviewer(s)

- [x] Corresponding issue(s) is/are linked and addressed
- [x] Code is clean of development artifacts (no deactivated or commented code lines, no debugging printouts, etc.)
- [x] Appropriate **unit tests** have been added, CI passes and code coverage is acceptable (did not decrease)
- [x] No large data files added in the whole history of commits(files should in sum not exceed 100 KB, avoid PDFs, Word docs, etc.)
