### PR TITLE
808 inconsistent data for different start dates

### DIFF
--- a/pycode/memilio-epidata/memilio/epidata/getCaseData.py
+++ b/pycode/memilio-epidata/memilio/epidata/getCaseData.py
@@ -137,6 +137,9 @@ def get_case_data(read_data=dd.defaultDict['read_data'],
     if files == 'Plot':
         # only consider plotable files
         files = ['infected', 'deaths', 'all_gender', 'all_age']
+    # handle error of passing a string of one file instead of a list
+    if isinstance(files, str):
+        files = [files]
 
     directory = os.path.join(out_folder, 'Germany/')
     gd.check_dir(directory)

--- a/pycode/memilio-epidata/memilio/epidata/modifyDataframeSeries.py
+++ b/pycode/memilio-epidata/memilio/epidata/modifyDataframeSeries.py
@@ -88,9 +88,9 @@ def impute_and_reduce_df(
     except:
         pass
     # range of dates which should be in output
-    if min_date is None:
+    if (min_date is None) or (min_date == ''):
         min_date = first_date
-    if max_date is None:
+    if (max_date is None) or (max_date == ''):
         max_date = last_date
 
     # Transform dates to datetime

--- a/pycode/memilio-epidata/memilio/epidata/modifyDataframeSeries.py
+++ b/pycode/memilio-epidata/memilio/epidata/modifyDataframeSeries.py
@@ -87,7 +87,6 @@ def impute_and_reduce_df(
         last_date = last_date.date()
     except:
         pass
-
     # range of dates which should be in output
     if min_date is None:
         min_date = first_date
@@ -99,6 +98,12 @@ def impute_and_reduce_df(
         min_date = datetime.strptime(min_date, "%Y-%m-%d")
     if isinstance(max_date, str) == True:
         max_date = datetime.strptime(max_date, "%Y-%m-%d")
+
+    try:
+        min_date = min_date.date()
+        max_date = max_date.date()
+    except:
+        pass
 
     # shift start and end date for relevant dates to compute moving average.
     # if moving average is odd, both dates are shifted equaly.

--- a/pycode/memilio-epidata/memilio/epidata/modifyDataframeSeries.py
+++ b/pycode/memilio-epidata/memilio/epidata/modifyDataframeSeries.py
@@ -81,6 +81,13 @@ def impute_and_reduce_df(
     if isinstance(last_date, str) == True:
         last_date = datetime.strptime(last_date, "%Y-%m-%d")
 
+    # Transform timestamp to date
+    try:
+        first_date = first_date.date()
+        last_date = last_date.date()
+    except:
+        pass
+
     # range of dates which should be in output
     if min_date is None:
         min_date = first_date

--- a/pycode/memilio-epidata/memilio/epidata/modifyDataframeSeries.py
+++ b/pycode/memilio-epidata/memilio/epidata/modifyDataframeSeries.py
@@ -99,8 +99,10 @@ def impute_and_reduce_df(
     if moving_average > 0:
         first_date = first_date - timedelta(int(np.ceil((moving_average-1)/2)))
         last_date = last_date + timedelta(int(np.floor((moving_average-1)/2)))
-        min_date_to_use = min_date - timedelta(int(np.ceil((moving_average-1)/2)))
-        max_date_to_use = max_date + timedelta(int(np.floor((moving_average-1)/2)))
+        min_date_to_use = min_date - \
+            timedelta(int(np.ceil((moving_average-1)/2)))
+        max_date_to_use = max_date + \
+            timedelta(int(np.floor((moving_average-1)/2)))
         if first_date > min_date_to_use:
             first_date = min_date_to_use
         if last_date < max_date_to_use:
@@ -160,7 +162,8 @@ def impute_and_reduce_df(
             # compute 'moving average'-days moving average
             if moving_average > 0:
                 # extract subframe to prevent unnecessary computation
-                df_local_new = extract_subframe_based_on_dates(df_local_new, min_date_to_use, max_date_to_use)
+                df_local_new = extract_subframe_based_on_dates(
+                    df_local_new, min_date_to_use, max_date_to_use)
                 for avg in mod_cols:
                     # compute moving average in new column
                     df_local_new['MA' + avg] = df_local_new[avg].rolling(

--- a/pycode/memilio-epidata/memilio/epidata/modifyDataframeSeries.py
+++ b/pycode/memilio-epidata/memilio/epidata/modifyDataframeSeries.py
@@ -97,10 +97,14 @@ def impute_and_reduce_df(
     # if moving average is odd, both dates are shifted equaly.
     # if moving average is even, start date is shifted one day more than end date.
     if moving_average > 0:
-        first_date = first_date - timedelta(int(np.floor((moving_average-1)/2)))
-        last_date = last_date + timedelta(int(np.ceil((moving_average-1)/2)))
-        min_date_to_use = min_date - timedelta(int(np.floor((moving_average-1)/2)))
+        first_date = first_date - timedelta(int(np.ceil((moving_average-1)/2)))
+        last_date = last_date + timedelta(int(np.floor((moving_average-1)/2)))
+        min_date_to_use = min_date - timedelta(int(np.ceil((moving_average-1)/2)))
         max_date_to_use = max_date + timedelta(int(np.floor((moving_average-1)/2)))
+        if first_date > min_date_to_use:
+            first_date = min_date_to_use
+        if last_date < max_date_to_use:
+            last_date = max_date_to_use
 
     idx = pd.date_range(first_date, last_date)
 

--- a/pycode/memilio-epidata/memilio/epidata/modifyDataframeSeries.py
+++ b/pycode/memilio-epidata/memilio/epidata/modifyDataframeSeries.py
@@ -87,16 +87,16 @@ def impute_and_reduce_df(
         last_date = last_date.date()
     except:
         pass
+
     # range of dates which should be in output
+    # Transform dates to datetime
     if (min_date is None) or (min_date == ''):
         min_date = first_date
+    elif isinstance(min_date, str) == True:
+        min_date = datetime.strptime(min_date, "%Y-%m-%d")
     if (max_date is None) or (max_date == ''):
         max_date = last_date
-
-    # Transform dates to datetime
-    if isinstance(min_date, str) == True:
-        min_date = datetime.strptime(min_date, "%Y-%m-%d")
-    if isinstance(max_date, str) == True:
+    elif isinstance(max_date, str) == True:
         max_date = datetime.strptime(max_date, "%Y-%m-%d")
 
     try:


### PR DESCRIPTION
# Changes and Information

Please **briefly list the changes** made, additional Information and what the Reviewer should look out for:

Cumulative sum and imputation of dates are now done for all dates independent of `start_date` and `end_date`.
Moving average is calculated afterward.

Some files of case data, vaccination data and divi data (the ones reported in the corresponding issues) are checked and the dataframes have the same data independent of `start_date`.

## Merge Request - Guideline Checklist

Please check our [git workflow](https://github.com/DLR-SC/memilio/wiki/git-workflow). Use the **draft** feature if the Pull Request is not yet ready to review.

### Checks by code author

- [x] Every addressed issue is linked (use the "Closes #ISSUE" keyword below)
- [x] New code adheres to [coding guidelines](https://github.com/DLR-SC/memilio/wiki/Coding-guidelines)
- [x] No large data files have been added (files should in sum not exceed 100 KB, avoid PDFs, Word docs, etc.)
- [ ] Tests are added for new functionality and a local test run was successful
- [x] Appropriate **documentation** for new functionality has been added (Doxygen in the code and Markdown files if necessary)
- [ ] Proper attention to licenses, especially no new third-party software with conflicting license has been added

### Checks by code reviewer(s)

- [x] Corresponding issue(s) is/are linked and addressed
- [x] Code is clean of development artifacts (no deactivated or commented code lines, no debugging printouts, etc.)
- [x] Appropriate **unit tests** have been added, CI passes and code coverage is acceptable (did not decrease)
- [x] No large data files added in the whole history of commits(files should in sum not exceed 100 KB, avoid PDFs, Word docs, etc.)

Closes #796 
Closes #806 
Closes #807 
Closes #808 