### PR TITLE
898 change test for valid transition distibution from ide model

### DIFF
--- a/cpp/models/ide_secir/model.h
+++ b/cpp/models/ide_secir/model.h
@@ -173,6 +173,8 @@ public:
      * @param[in] idx_TransitionDistribution2 Specifies the index of the second relevant TransitionDistribution, 
      *              related to a flow from the considered #InfectionState to any other #InfectionState (in most cases to Recovered). 
      *              Necessary related probability is calculated via 1-probability[idx_TransitionDistribution1].
+     *              If the second index is not needed, eg if probability[idx_TransitionDistribution1]=1, 
+     *              just use an arbitrary legal index.
      * @param[in] dt Time discretization step size.
      */
     void compute_compartment(Eigen::Index idx_InfectionState, Eigen::Index idx_IncomingFlow,

--- a/cpp/models/ide_secir/parameters.h
+++ b/cpp/models/ide_secir/parameters.h
@@ -270,9 +270,9 @@ public:
             return true;
         }
 
-        for (size_t i = 0; i < (int)InfectionTransition::Count; i++) {
+        for (size_t i = 1; i < (int)InfectionTransition::Count; i++) {
             if (floating_point_less(this->get<TransitionDistributions>()[i].get_support_max(10), 0.0, 1e-14)) {
-                log_error("Constraint check: One parameter in TransitionDistributions has invalid support.");
+                log_error("Constraint check: One function in TransitionDistributions has invalid support.");
                 return true;
             }
         }

--- a/cpp/models/ide_secir/parameters.h
+++ b/cpp/models/ide_secir/parameters.h
@@ -269,7 +269,8 @@ public:
                       1);
             return true;
         }
-
+        /* The first entry of TransitionDistributions is not checked because the distribution S->E is never used 
+        (and it makes no sense to use the distribution). The support does not need to be valid.*/
         for (size_t i = 1; i < (int)InfectionTransition::Count; i++) {
             if (floating_point_less(this->get<TransitionDistributions>()[i].get_support_max(10), 0.0, 1e-14)) {
                 log_error("Constraint check: One function in TransitionDistributions has invalid support.");


### PR DESCRIPTION
# Changes and Information

Please **briefly list the changes** (main added features, changed items, or corrected bugs) made:

- Changed the index of a test in check_constraints for the ide model because the transitiondistribution S-> E is never used, so it does not have to have valid support. This can lead to unexpected errors if the function was set arbitrarily.


## Merge Request - Guideline Checklist

Please check our [git workflow](https://github.com/SciCompMod/memilio/wiki/git-workflow). Use the **draft** feature if the Pull Request is not yet ready to review.

### Checks by code author

- [x] Every addressed issue is linked (use the "Closes #ISSUE" keyword below)
- [x] New code adheres to [coding guidelines](https://github.com/SciCompMod/memilio/wiki/Coding-guidelines)
- [x] No large data files have been added (files should in sum not exceed 100 KB, avoid PDFs, Word docs, etc.)
- [x] Tests are added for new functionality and a local test run was successful
- [x] Appropriate **documentation** for new functionality has been added (Doxygen in the code and Markdown files if necessary)
- [x] Proper attention to licenses, especially no new third-party software with conflicting license has been added
- [ ] (For ABM development) Checked [benchmark results](https://github.com/SciCompMod/memilio/wiki/Agent-Based-Model-Development) and ran and posted a local test above from before and after development to ensure performance is monitored.

### Checks by code reviewer(s)

- [x] Corresponding issue(s) is/are linked and addressed
- [x] Code is clean of development artifacts (no deactivated or commented code lines, no debugging printouts, etc.)
- [x] Appropriate **unit tests** have been added, CI passes, code coverage and performance is acceptable (did not decrease)
- [x] No large data files added in the whole history of commits(files should in sum not exceed 100 KB, avoid PDFs, Word docs, etc.)
- [x] On merge, add 2-5 lines with the changes (main added features, changed items, or corrected bugs) to the merge-commit-message. This can be taken from the **briefly-list-the-changes** above (best case) or the separate commit messages (worst case).

Closes #898 