### PR TITLE
fix parameter rendering by doxygen

### DIFF
--- a/pycode/memilio-epidata/memilio/epidata/progress_indicator.py
+++ b/pycode/memilio-epidata/memilio/epidata/progress_indicator.py
@@ -27,10 +27,9 @@ from os import name as os_name
 
 class ProgressIndicator:
     """! Print an animation to show that something is happening.
-
     Animations are rendered in a new thread, which is set up as deamon so that
     it stops on main thread exit.
-    The methods Dots, Spinner and Percentage provide some default animations.
+    The subclasses Dots, Spinner and Percentage provide some default animations.
     Start the animation by either using the `start`/`stop` functions or a
     'with as' block, e.g
     ```
@@ -51,16 +50,15 @@ class ProgressIndicator:
 
     def __init__(self, message, animator, delay, auto_adjust=False):
         """! Create a ProgressIndicator.
-
         @param message String. Shown in front of the animation without
             seperator. If it would not fit in a single line with the
             animation, it will be printed once in a new line above the
-            animation instead. Must not contain `\\r` or `\\n`.
+            animation instead. Must not contain `\r` or `\n`.
         @param animator Generator expression. The expression must loop, i.e.
             it should never return StopIteration. `next(animator)` must be a
             string of length < `os.get_terminal_size().columns`. The length
             should be constant, otherwise animations may leave artifacts (this
-            can be worked around by prepending `"\\033[K"` to each string).
+            can be worked around by prepending `"\033[K"` to each string).
         @param delay Positive real number. Sets delay in seconds between
             drawing animation frames.
         @param auto_adjust [Default: False] Bool. Specify whether each frame
@@ -83,16 +81,17 @@ class ProgressIndicator:
             ProgressIndicator._console_setup()
 
     def __enter__(self):
+        """! Calls start at the beginning of a 'with' block. """
         self.start()
         return self
 
     def __exit__(self, exception, value, trace):
+        """! Calls stop at the end of a 'with' block. """
         self.stop()
 
     @staticmethod
     def disable_indicators(disable):
         """! Globally prevents new indicators from starting.
-
         This does not affect currently running indicators.
 
         @param disable Bool. If True, no new indicators can be started.
@@ -102,6 +101,7 @@ class ProgressIndicator:
 
     @staticmethod
     def _console_setup():
+        """! Set up the console evironment. """
         if os_name == 'nt':  # os name can be nt, posix, or java
             # Windows uses nt, which does not support carriage returns by
             # default. the following Windows specific module should fix this.
@@ -148,7 +148,7 @@ class ProgressIndicator:
         @param message String. Shown in front of the animation without
             seperator. If it would not fit in a single line with the
             animation, it will be printed once in a new line above the
-            animation instead. Must not contain `\\r` or `\\n`.
+            animation instead. Must not contain `\r` or `\n`.
         """
         self._message = message
         self._adjust_to_terminal_size()
@@ -166,8 +166,7 @@ class ProgressIndicator:
 
     def start(self):
         """! Start the animation in a new thread.
-
-        Must call stop() afterwards.
+        Must call stop afterwards.
         """
         if not ProgressIndicator._disabled and not self._thread_is_running:
             self._thread_is_running = True
@@ -189,8 +188,7 @@ class Spinner(ProgressIndicator):
     """! Subclass of ProgressIndicator with a predefined animation. """
 
     def __init__(self, delay=0.1, message=""):
-        """! initializes a ProgressIndicator with a rotating line animation.
-
+        """! Initializes a ProgressIndicator with a rotating line animation.
         This method spawns a new thread to print the animation.
         Start the animation by either using the `start`/`stop` functions or a
         'with' block.
@@ -209,8 +207,7 @@ class Dots(ProgressIndicator):
     """! Subclass of ProgressIndicator with a predefined animation. """
 
     def __init__(self, delay=1, message="", num_dots=3, dot=".", blank=" "):
-        """! initializes ProgressIndicator with a 'dot, dot, dot' animation.
-
+        """! Initializes ProgressIndicator with a 'dot, dot, dot' animation.
         This method spawns a new thread to print the animation.
         Start the animation by either using the `start`/`stop` functions or a
         'with' block.
@@ -232,16 +229,16 @@ class Dots(ProgressIndicator):
                 for n in range(1, num_dots+1):  # iterate animation frames
                     # return single frame
                     yield f"{dot*n}{blank*(num_dots-n)}"
+
         super().__init__(message + " ", _dots(), delay)
 
 
 class Percentage(ProgressIndicator):
-    """! Manages a ProgressIndicator with a predefined animation. """
+    """! Subclass of ProgressIndicator with a predefined animation. """
 
     def __init__(self, delay=1, message="", percentage=0, use_bar=True,
                  keep_output=False):
-        """! initializes ProgressIndicator displaying a percentage.
-
+        """! Initializes ProgressIndicator displaying a percentage.
         The percentage can be updated using the `set_progress` method.
         By default, this method spawns a new thread to print the animation.
         Start the animation by either using the `start`/`stop` functions or a
@@ -272,6 +269,7 @@ class Percentage(ProgressIndicator):
         def _perc():
             while True:
                 yield f"{100*self._progress:6.2f}%"
+
         super().__init__(message + " ", _perc(), delay, use_bar)
 
     def _advance(self):
@@ -284,7 +282,6 @@ class Percentage(ProgressIndicator):
 
     def start(self):
         """! Start the animation. Must call stop() afterwards.
-
         If delay > 0, this method spawns a new thread.
         """
         self._disabled = ProgressIndicator._disabled
@@ -305,7 +302,6 @@ class Percentage(ProgressIndicator):
 
     def set_progress(self, percentage):
         """! Updates the percentage shown by the indicator. Steps if delay = 0.
-
         @param percentage real number. Must be in the interval [0, 1].
         """
         self._progress = percentage
@@ -315,7 +311,6 @@ class Percentage(ProgressIndicator):
     @staticmethod
     def _bar(width, percentage):
         """! Returns a progress bar.
-
         @param width Total width of the bar. Must be at least 4.
         @param percentage Float in [0,1].
         @return String of length width, visualizing percentage.


### PR DESCRIPTION
# Changes and Information

The parameters from this file where incorrectly rendered in doxygen. Removing the newline after the summary fixed that.
Also added or updated a few short descriptions.

## Merge Request - Guideline Checklist

Please check our [git workflow](https://github.com/SciCompMod/memilio/wiki/git-workflow). Use the **draft** feature if the Pull Request is not yet ready to review.

### Checks by code author

- [x] Every addressed issue is linked (use the "Closes #ISSUE" keyword below)
- [x] New code adheres to [coding guidelines](https://github.com/SciCompMod/memilio/wiki/Coding-guidelines)
- [x] No large data files have been added (files should in sum not exceed 100 KB, avoid PDFs, Word docs, etc.)
- [x] Tests are added for new functionality and a local test run was successful
- [x] Appropriate **documentation** for new functionality has been added (Doxygen in the code and Markdown files if necessary)
- [x] Proper attention to licenses, especially no new third-party software with conflicting license has been added
- [x] (For ABM development) Checked [benchmark results](https://github.com/SciCompMod/memilio/wiki/Agent-Based-Model-Development) and ran and posted a local test above from before and after development to ensure performance is monitored.

### Checks by code reviewer(s)

- [ ] Corresponding issue(s) is/are linked and addressed
- [x] Code is clean of development artifacts (no deactivated or commented code lines, no debugging printouts, etc.)
- [x] Appropriate **unit tests** have been added, CI passes, code coverage and performance is acceptable (did not decrease)
- [x] No large data files added in the whole history of commits(files should in sum not exceed 100 KB, avoid PDFs, Word docs, etc.)
- [ ] On merge, add 2-5 lines with the changes (main added features, changed items, or corrected bugs) to the merge-commit-message. This can be taken from the **briefly-list-the-changes** above (best case) or the separate commit messages (worst case).
