### PR TITLE
958 implement a check for the results of the initialization

### DIFF
--- a/cpp/README.md
+++ b/cpp/README.md
@@ -4,7 +4,7 @@ The MEmilio C++ library contains the implementation of the epidemiological model
 
 Directory structure:
 - memilio: framework for developing epidemiological models with, e.g., interregional mobility implementations, nonpharmaceutical interventions (NPIs), and  mathematical, programming, and IO utilities.
-- models: implementation of concrete models (ODE and ABM)
+- models: implementation of concrete models (ODE, IDE, LCT and ABM)
 - simulations: simulation applications that were used to generate the scenarios and data for publications
 - examples: small applications that help with using the framework and models
 - tests: unit tests for framework and models.

--- a/cpp/models/ide_secir/model.cpp
+++ b/cpp/models/ide_secir/model.cpp
@@ -130,6 +130,19 @@ void Model::initialize(ScalarType dt)
                       "larger 0.");
         }
     }
+
+    // Verify that the initialization produces an appropriate result.
+    // Another check would be if the sum of the compartments is equal to N, but in all initialization methods one of the compartments is initialized via N - the others.
+    // This also means that if a compartment is greater than N, we will always have one or more compartments less than zero.
+    // Check if all compartments are non negative.
+    for (int i = 0; i < (int)InfectionState::Count; i++) {
+        if (m_populations[0][i] < 0) {
+            m_initialization_method = -2;
+            log_error("Initialization failed. One or more initial values for populations are less than zero. It may "
+                      "help to use a different method for initialization.");
+        }
+    }
+
     // Compute m_forceofinfection at time 0 needed for further simulation.
     update_forceofinfection(dt);
 }

--- a/cpp/models/ide_secir/model.cpp
+++ b/cpp/models/ide_secir/model.cpp
@@ -66,6 +66,38 @@ void Model::initialize(ScalarType dt)
             m_populations[Eigen::Index(0)][Eigen::Index(InfectionState::Recovered)] -
             m_populations[Eigen::Index(0)][Eigen::Index(InfectionState::Dead)];
     }
+    else if (m_populations[Eigen::Index(0)][Eigen::Index(InfectionState::Susceptible)] > 1e-12) {
+        //take initialized value for Susceptibles if value can't be calculated via the standard formula
+        m_initialization_method = 2;
+        //calculate other compartment sizes for t=0
+        other_compartments_current_timestep(dt);
+
+        //R; need an initial value for R, therefore do not calculate via compute_recovered()
+        m_populations[Eigen::Index(0)][Eigen::Index(InfectionState::Recovered)] =
+            m_N - m_populations[Eigen::Index(0)][Eigen::Index(InfectionState::Susceptible)] -
+            m_populations[Eigen::Index(0)][Eigen::Index(InfectionState::Exposed)] -
+            m_populations[Eigen::Index(0)][Eigen::Index(InfectionState::InfectedNoSymptoms)] -
+            m_populations[Eigen::Index(0)][Eigen::Index(InfectionState::InfectedSymptoms)] -
+            m_populations[Eigen::Index(0)][Eigen::Index(InfectionState::InfectedSevere)] -
+            m_populations[Eigen::Index(0)][Eigen::Index(InfectionState::InfectedCritical)] -
+            m_populations[Eigen::Index(0)][Eigen::Index(InfectionState::Dead)];
+    }
+    else if (m_populations[Eigen::Index(0)][Eigen::Index(InfectionState::Recovered)] > 1e-12) {
+        //if value for Recovered is initialized and standard method is not applicable, calculate Susceptibles via other compartments
+        //determining other compartment sizes is not dependent of Susceptibles(0), just of the transitions of the past.
+        //calculate other compartment sizes for t=0
+        m_initialization_method = 3;
+        other_compartments_current_timestep(dt);
+
+        m_populations[Eigen::Index(0)][Eigen::Index(InfectionState::Susceptible)] =
+            m_N - m_populations[Eigen::Index(0)][Eigen::Index(InfectionState::Exposed)] -
+            m_populations[Eigen::Index(0)][Eigen::Index(InfectionState::InfectedNoSymptoms)] -
+            m_populations[Eigen::Index(0)][Eigen::Index(InfectionState::InfectedSymptoms)] -
+            m_populations[Eigen::Index(0)][Eigen::Index(InfectionState::InfectedSevere)] -
+            m_populations[Eigen::Index(0)][Eigen::Index(InfectionState::InfectedCritical)] -
+            m_populations[Eigen::Index(0)][Eigen::Index(InfectionState::Recovered)] -
+            m_populations[Eigen::Index(0)][Eigen::Index(InfectionState::Dead)];
+    }
     else {
 
         // compute Susceptibles at time 0  and m_forceofinfection at time -dt as initial values for discretization scheme
@@ -73,7 +105,7 @@ void Model::initialize(ScalarType dt)
         // where also the value of m_forceofinfection for the previous timestep is used
         update_forceofinfection(dt, true);
         if (m_forceofinfection > 1e-12) {
-            m_initialization_method = 2;
+            m_initialization_method = 4;
             m_populations[Eigen::Index(0)][Eigen::Index(InfectionState::Susceptible)] =
                 m_transitions.get_last_value()[Eigen::Index(InfectionTransition::SusceptibleToExposed)] /
                 (dt * m_forceofinfection);
@@ -91,38 +123,6 @@ void Model::initialize(ScalarType dt)
                 m_populations[Eigen::Index(0)][Eigen::Index(InfectionState::InfectedCritical)] -
                 m_populations[Eigen::Index(0)][Eigen::Index(InfectionState::Dead)];
         }
-        else if (m_populations[Eigen::Index(0)][Eigen::Index(InfectionState::Susceptible)] > 1e-12) {
-            //take initialized value for Susceptibles if value can't be calculated via the standard formula
-            m_initialization_method = 3;
-            //calculate other compartment sizes for t=0
-            other_compartments_current_timestep(dt);
-
-            //R; need an initial value for R, therefore do not calculate via compute_recovered()
-            m_populations[Eigen::Index(0)][Eigen::Index(InfectionState::Recovered)] =
-                m_N - m_populations[Eigen::Index(0)][Eigen::Index(InfectionState::Susceptible)] -
-                m_populations[Eigen::Index(0)][Eigen::Index(InfectionState::Exposed)] -
-                m_populations[Eigen::Index(0)][Eigen::Index(InfectionState::InfectedNoSymptoms)] -
-                m_populations[Eigen::Index(0)][Eigen::Index(InfectionState::InfectedSymptoms)] -
-                m_populations[Eigen::Index(0)][Eigen::Index(InfectionState::InfectedSevere)] -
-                m_populations[Eigen::Index(0)][Eigen::Index(InfectionState::InfectedCritical)] -
-                m_populations[Eigen::Index(0)][Eigen::Index(InfectionState::Dead)];
-        }
-        else if (m_populations[Eigen::Index(0)][Eigen::Index(InfectionState::Recovered)] > 1e-12) {
-            //if value for Recovered is initialized and standard method is not applicable, calculate Susceptibles via other compartments
-            //determining other compartment sizes is not dependent of Susceptibles(0), just of the transitions of the past.
-            //calculate other compartment sizes for t=0
-            m_initialization_method = 4;
-            other_compartments_current_timestep(dt);
-
-            m_populations[Eigen::Index(0)][Eigen::Index(InfectionState::Susceptible)] =
-                m_N - m_populations[Eigen::Index(0)][Eigen::Index(InfectionState::Exposed)] -
-                m_populations[Eigen::Index(0)][Eigen::Index(InfectionState::InfectedNoSymptoms)] -
-                m_populations[Eigen::Index(0)][Eigen::Index(InfectionState::InfectedSymptoms)] -
-                m_populations[Eigen::Index(0)][Eigen::Index(InfectionState::InfectedSevere)] -
-                m_populations[Eigen::Index(0)][Eigen::Index(InfectionState::InfectedCritical)] -
-                m_populations[Eigen::Index(0)][Eigen::Index(InfectionState::Recovered)] -
-                m_populations[Eigen::Index(0)][Eigen::Index(InfectionState::Dead)];
-        }
         else {
             m_initialization_method = -1;
             log_error("Error occured while initializing compartments: Force of infection is evaluated to 0 and neither "
@@ -130,7 +130,7 @@ void Model::initialize(ScalarType dt)
                       "larger 0.");
         }
     }
-    // compute m_forceofinfection at time 0 needed for further simulation
+    // Compute m_forceofinfection at time 0 needed for further simulation.
     update_forceofinfection(dt);
 }
 

--- a/cpp/models/ide_secir/model.cpp
+++ b/cpp/models/ide_secir/model.cpp
@@ -67,12 +67,12 @@ void Model::initialize(ScalarType dt)
             m_populations[Eigen::Index(0)][Eigen::Index(InfectionState::Dead)];
     }
     else if (m_populations[Eigen::Index(0)][Eigen::Index(InfectionState::Susceptible)] > 1e-12) {
-        //take initialized value for Susceptibles if value can't be calculated via the standard formula
+        // Take initialized value for Susceptibles if value can't be calculated via the standard formula.
         m_initialization_method = 2;
-        //calculate other compartment sizes for t=0
+        // Calculate other compartment sizes for t=0.
         other_compartments_current_timestep(dt);
 
-        //R; need an initial value for R, therefore do not calculate via compute_recovered()
+        // R; need an initial value for R, therefore do not calculate via compute_recovered()
         m_populations[Eigen::Index(0)][Eigen::Index(InfectionState::Recovered)] =
             m_N - m_populations[Eigen::Index(0)][Eigen::Index(InfectionState::Susceptible)] -
             m_populations[Eigen::Index(0)][Eigen::Index(InfectionState::Exposed)] -
@@ -83,9 +83,9 @@ void Model::initialize(ScalarType dt)
             m_populations[Eigen::Index(0)][Eigen::Index(InfectionState::Dead)];
     }
     else if (m_populations[Eigen::Index(0)][Eigen::Index(InfectionState::Recovered)] > 1e-12) {
-        //if value for Recovered is initialized and standard method is not applicable, calculate Susceptibles via other compartments
-        //determining other compartment sizes is not dependent of Susceptibles(0), just of the transitions of the past.
-        //calculate other compartment sizes for t=0
+        // If value for Recovered is initialized and standard method is not applicable (i.e., no value for total infections
+        //  or suceptibles given directly), calculate Susceptibles via other compartments.
+        // The calculation of other compartments' values is not dependent on Susceptibles at time 0, i.e., S(0), but only on the transitions of the past.
         m_initialization_method = 3;
         other_compartments_current_timestep(dt);
 

--- a/cpp/models/ide_secir/model.cpp
+++ b/cpp/models/ide_secir/model.cpp
@@ -99,13 +99,18 @@ void Model::initialize(ScalarType dt)
             m_populations[Eigen::Index(0)][Eigen::Index(InfectionState::Dead)];
     }
     else {
-
         // compute Susceptibles at time 0  and m_forceofinfection at time -dt as initial values for discretization scheme
         // use m_forceofinfection at -dt to be consistent with further calculations of S (see compute_susceptibles()),
         // where also the value of m_forceofinfection for the previous timestep is used
         update_forceofinfection(dt, true);
         if (m_forceofinfection > 1e-12) {
             m_initialization_method = 4;
+
+            /* Attention: With an inappropriate combination of parameters and initial conditions, it can happen that S 
+            becomes greater than N when this formula is used. In this case, at least one compartment is initialized 
+            with a number less than zero, so that a log_error is thrown.
+            However, this initialization method is consistent with the numerical solver of the model equations,
+            so it may sometimes make sense to use this method. */
             m_populations[Eigen::Index(0)][Eigen::Index(InfectionState::Susceptible)] =
                 m_transitions.get_last_value()[Eigen::Index(InfectionTransition::SusceptibleToExposed)] /
                 (dt * m_forceofinfection);

--- a/cpp/models/ide_secir/model.h
+++ b/cpp/models/ide_secir/model.h
@@ -94,11 +94,18 @@ public:
     }
 
     /**
-     * @brief Calculate the number of individuals in each compartment for time 0.
-     * 
-     * Initial transitions are used to calculate the initial compartment sizes.
-     * @param[in] dt Time discretization step size.         
-     */
+    * @brief Initializes the model and sets compartment values at time zero.
+    *
+    * The initialization method is selected automatically based on the different values that need to be set beforehand.
+    * Infection compartments are always computed through historic flow.
+    * Initialization methods for susceptibles and recovered are tested in the following order:
+    * 1.) If a positive number for the total number of confirmed cases is set, recovered is set according to that value and #Susceptible%s are derived.
+    * 2.) If #Susceptible%s are set, recovered will be derived.
+    * 3.) If #Recovered are set directly, #Susceptible%s are derived.
+    * 4.) If none of the above is set with positive value, the force of infection is used as in Messina et al (2021) to set the #Susceptible%s.
+    *
+    * @param[in] dt Time discretization step size.         
+    */
     void initialize(ScalarType dt);
 
     /**
@@ -201,12 +208,12 @@ public:
     }
 
     /**
-     * @brief Specifies a number associated with the method used for initialization.
+     * @brief Returns the number associated with the method selected automatically for initialization.
      *
-     * @returns 0 if the initialization method has not yet been selected,
+    * @returns 0 if the model has not yet been initialized and the method has not yet been selected,
      *      1 if the method using the total number of confirmed cases at time 0 is used,
-     *      2 if the initialization is calculated using a prior set value for S,
-     *      3 if the initialization is calculated using a prior set value for R,
+     *      2 if the initialization is calculated using a beforehand set value for S,
+     *      3 if the initialization is calculated using a beforehand set value for R,
      *      4 if the force of infection method is used, 
      *      -1 if the initialization was not possible using any of the methods and
      *      -2 if the initialization was possible using one of the provided methods but the result is not appropriate.

--- a/cpp/models/ide_secir/model.h
+++ b/cpp/models/ide_secir/model.h
@@ -59,16 +59,9 @@ public:
     bool check_constraints(ScalarType dt) const
     {
         if (!((int)m_transitions.get_num_elements() == (int)InfectionTransition::Count)) {
-            log_error(
-                "Initialization failed. Number of elements in transition vector does not match the required number.");
+            log_error("A variable given for model construction is not valid. Number of elements in transition vector "
+                      "does not match the required number.");
             return true;
-        }
-
-        for (int i = 0; i < (int)InfectionState::Count; i++) {
-            if (m_populations[0][i] < 0) {
-                log_error("Initialization failed. Initial values for populations are less than zero.");
-                return true;
-            }
         }
 
         ScalarType support_max = std::max(
@@ -213,9 +206,10 @@ public:
      * @returns 0 if the initialization method has not yet been selected,
      *      1 if the method using the total number of confirmed cases at time 0 is used,
      *      2 if the initialization is calculated using a prior set value for S,
-     *      3 if the initialization is calculated using a prior set value for R 
-     *      4 if the force of infection method is used,and
-     *      -1 if the initialization was not possible using any of the methods.
+     *      3 if the initialization is calculated using a prior set value for R,
+     *      4 if the force of infection method is used, 
+     *      -1 if the initialization was not possible using any of the methods and
+     *      -2 if the initialization was possible using one of the provided methods but the result is not appropriate.
      */
     int get_initialization_method()
     {

--- a/cpp/models/ide_secir/model.h
+++ b/cpp/models/ide_secir/model.h
@@ -212,9 +212,9 @@ public:
      *
      * @returns 0 if the initialization method has not yet been selected,
      *      1 if the method using the total number of confirmed cases at time 0 is used,
-     *      2 if the force of infection method is used,
-     *      3 if the initialization is calculated using a prior set value for S,
-     *      4 if the initialization is calculated using a prior set value for R and
+     *      2 if the initialization is calculated using a prior set value for S,
+     *      3 if the initialization is calculated using a prior set value for R 
+     *      4 if the force of infection method is used,and
      *      -1 if the initialization was not possible using any of the methods.
      */
     int get_initialization_method()

--- a/cpp/tests/test_ide_secir.cpp
+++ b/cpp/tests/test_ide_secir.cpp
@@ -281,17 +281,6 @@ TEST(IdeSecir, checkInitializations)
     // Verify that the expected initialization method was used.
     EXPECT_EQ(1, sim1.get_model().get_initialization_method());
 
-    // --- Case with forceofinfection.
-    mio::TimeSeries<ScalarType> init_copy2(init);
-    mio::isecir::Model model2(std::move(init_copy2), N, deaths, 0);
-
-    // Carry out simulation.
-    mio::isecir::Simulation sim2(model2, 0, dt);
-    sim2.advance(tmax);
-
-    // Verify that the expected initialization method was used.
-    EXPECT_EQ(2, sim2.get_model().get_initialization_method());
-
     // --- Case with S.
     /* !! For the other tests, the contact rate is set to 0 so that the force of infection is zero.
      The forceofinfection initialization method is therefore not used for these tests.*/
@@ -311,7 +300,7 @@ TEST(IdeSecir, checkInitializations)
     sim3.advance(tmax);
 
     // Verify that the expected initialization method was used.
-    EXPECT_EQ(3, sim3.get_model().get_initialization_method());
+    EXPECT_EQ(2, sim3.get_model().get_initialization_method());
 
     // --- Case with R.
     mio::TimeSeries<ScalarType> init_copy4(init);
@@ -325,7 +314,18 @@ TEST(IdeSecir, checkInitializations)
     sim4.advance(tmax);
 
     // Verify that the expected initialization method was used.
-    EXPECT_EQ(4, sim4.get_model().get_initialization_method());
+    EXPECT_EQ(3, sim4.get_model().get_initialization_method());
+
+    // --- Case with forceofinfection.
+    mio::TimeSeries<ScalarType> init_copy2(init);
+    mio::isecir::Model model2(std::move(init_copy2), N, deaths, 0);
+
+    // Carry out simulation.
+    mio::isecir::Simulation sim2(model2, 0, dt);
+    sim2.advance(tmax);
+
+    // Verify that the expected initialization method was used.
+    EXPECT_EQ(4, sim2.get_model().get_initialization_method());
 
     // --- Case without fitting initialization method.
     // Deactivate temporarily log output for next test. Error is expected here.


### PR DESCRIPTION
# Changes and Information

Please **briefly list the changes** (main added features, changed items, or corrected bugs) made:

- Previously, the value for S or R that was set may not have been used, so the information is lost. If one of the values has been set, this method of initialization should be preferred over the force of infection method. This is done by changing the order of the initialization methods.
- The check if all of the compartments are >0 is more appropriate after the initialization, so the location is changed (from check_constraints function to the initialization method).


If need be, add additional information and what the reviewer should look out for in particular:

- Merged #923 because there were some changes in the function check_constraints, that were important here.
- Maybe you have an additional idea what to check?

## Merge Request - Guideline Checklist

Please check our [git workflow](https://github.com/SciCompMod/memilio/wiki/git-workflow). Use the **draft** feature if the Pull Request is not yet ready to review.

### Checks by code author

- [x] Every addressed issue is linked (use the "Closes #ISSUE" keyword below)
- [x] New code adheres to [coding guidelines](https://github.com/SciCompMod/memilio/wiki/Coding-guidelines)
- [x] No large data files have been added (files should in sum not exceed 100 KB, avoid PDFs, Word docs, etc.)
- [x] Tests are added for new functionality and a local test run was successful (with and without OpenMP)
- [x] Appropriate **documentation** for new functionality has been added (Doxygen in the code and Markdown files if necessary)
- [x] Proper attention to licenses, especially no new third-party software with conflicting license has been added
- [ ] (For ABM development) Checked [benchmark results](https://github.com/SciCompMod/memilio/wiki/Agent-Based-Model-Development) and ran and posted a local test above from before and after development to ensure performance is monitored.

### Checks by code reviewer(s)

- [x] Corresponding issue(s) is/are linked and addressed
- [x] Code is clean of development artifacts (no deactivated or commented code lines, no debugging printouts, etc.)
- [x] Appropriate **unit tests** have been added, CI passes, code coverage and performance is acceptable (did not decrease)
- [x] No large data files added in the whole history of commits(files should in sum not exceed 100 KB, avoid PDFs, Word docs, etc.)
- [x] On merge, add 2-5 lines with the changes (main added features, changed items, or corrected bugs) to the merge-commit-message. This can be taken from the **briefly-list-the-changes** above (best case) or the separate commit messages (worst case).

Closes #958.