### PR TITLE
Add workaround to fix the CI

### DIFF
--- a/.github/actions/linux-build/action.yml
+++ b/.github/actions/linux-build/action.yml
@@ -44,8 +44,9 @@ inputs:
 runs:
   using: "composite"
   steps:
-      # copied from https://github.com/actions/runner-images/issues/9524#issuecomment-2002475952
+      # taken from https://github.com/actions/runner-images/issues/9524#issuecomment-2002475952
     - name: Fix kernel mmap rnd bits
+      shell: bash
       # Asan in llvm 14 provided in ubuntu 22.04 is incompatible with
       # high-entropy ASLR in much newer kernels that GitHub runners are
       # using leading to random crashes: https://reviews.llvm.org/D148280

--- a/.github/actions/linux-build/action.yml
+++ b/.github/actions/linux-build/action.yml
@@ -44,6 +44,12 @@ inputs:
 runs:
   using: "composite"
   steps:
+      # copied from https://github.com/actions/runner-images/issues/9524#issuecomment-2002475952
+    - name: Fix kernel mmap rnd bits
+      # Asan in llvm 14 provided in ubuntu 22.04 is incompatible with
+      # high-entropy ASLR in much newer kernels that GitHub runners are
+      # using leading to random crashes: https://reviews.llvm.org/D148280
+      run: sudo sysctl vm.mmap_rnd_bits=28
     - name: Install dependencies
       shell: bash
       run: |

--- a/.github/actions/linux-build/action.yml
+++ b/.github/actions/linux-build/action.yml
@@ -44,7 +44,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-      # taken from https://github.com/actions/runner-images/issues/9524#issuecomment-2002475952
+    # taken from https://github.com/actions/runner-images/issues/9524#issuecomment-2002475952
     - name: Fix kernel mmap rnd bits
       shell: bash
       # Asan in llvm 14 provided in ubuntu 22.04 is incompatible with

--- a/.github/actions/linux-run_examples/action.yml
+++ b/.github/actions/linux-run_examples/action.yml
@@ -7,6 +7,13 @@ inputs:
 runs:
   using: "composite"
   steps:
+    # taken from https://github.com/actions/runner-images/issues/9524#issuecomment-2002475952
+    - name: Fix kernel mmap rnd bits
+      shell: bash
+      # Asan in llvm 14 provided in ubuntu 22.04 is incompatible with
+      # high-entropy ASLR in much newer kernels that GitHub runners are
+      # using leading to random crashes: https://reviews.llvm.org/D148280
+      run: sudo sysctl vm.mmap_rnd_bits=28
     - name: Install Dependencies
       shell: bash
       run: |

--- a/.github/actions/linux-test/action.yml
+++ b/.github/actions/linux-test/action.yml
@@ -23,6 +23,13 @@ inputs:
 runs:
   using: "composite"
   steps:
+    # taken from https://github.com/actions/runner-images/issues/9524#issuecomment-2002475952
+    - name: Fix kernel mmap rnd bits
+      shell: bash
+      # Asan in llvm 14 provided in ubuntu 22.04 is incompatible with
+      # high-entropy ASLR in much newer kernels that GitHub runners are
+      # using leading to random crashes: https://reviews.llvm.org/D148280
+      run: sudo sysctl vm.mmap_rnd_bits=28
     - name: Install Dependencies
       shell: bash
       run: |


### PR DESCRIPTION
# Changes and Information

The CI currently fails due to a bug in Asan that got triggered by an update to the GitHub runner Ubuntu image. This PR adds a (presumably temporary) workaround, described [here](https://github.com/actions/runner-images/issues/9491#issuecomment-1989718917).

## Merge Request - Guideline Checklist

Please check our [git workflow](https://github.com/SciCompMod/memilio/wiki/git-workflow). Use the **draft** feature if the Pull Request is not yet ready to review.

### Checks by code author

- [ ] Every addressed issue is linked (use the "Closes #ISSUE" keyword below)
- [ ] New code adheres to [coding guidelines](https://github.com/SciCompMod/memilio/wiki/Coding-guidelines)
- [ ] No large data files have been added (files should in sum not exceed 100 KB, avoid PDFs, Word docs, etc.)
- [ ] Tests are added for new functionality and a local test run was successful (with and without OpenMP)
- [ ] Appropriate **documentation** for new functionality has been added (Doxygen in the code and Markdown files if necessary)
- [ ] Proper attention to licenses, especially no new third-party software with conflicting license has been added
- [ ] (For ABM development) Checked [benchmark results](https://github.com/SciCompMod/memilio/wiki/Agent-Based-Model-Development) and ran and posted a local test above from before and after development to ensure performance is monitored.

### Checks by code reviewer(s)

- [ ] Corresponding issue(s) is/are linked and addressed
- [ ] Code is clean of development artifacts (no deactivated or commented code lines, no debugging printouts, etc.)
- [ ] Appropriate **unit tests** have been added, CI passes, code coverage and performance is acceptable (did not decrease)
- [ ] No large data files added in the whole history of commits(files should in sum not exceed 100 KB, avoid PDFs, Word docs, etc.)
- [ ] On merge, add 2-5 lines with the changes (main added features, changed items, or corrected bugs) to the merge-commit-message. This can be taken from the **briefly-list-the-changes** above (best case) or the separate commit messages (worst case).
