### PR TITLE
977 remove t0 from simulation class and allow flexible start times in model

### DIFF
--- a/cpp/examples/ide_secir.cpp
+++ b/cpp/examples/ide_secir.cpp
@@ -94,7 +94,7 @@ int main()
     model.check_constraints(dt);
 
     // Carry out simulation.
-    mio::isecir::Simulation sim(model, 0, dt);
+    mio::isecir::Simulation sim(model, dt);
     sim.advance(tmax);
 
     sim.get_result().print_table({"S", "E", "C", "I", "H", "U", "R", "D "}, 16, 8);

--- a/cpp/models/ide_secir/model.h
+++ b/cpp/models/ide_secir/model.h
@@ -41,7 +41,7 @@ public:
     * @param[in, out] init TimeSeries with the initial values of the number of individuals, 
     *   which transit within one timestep dt from one compartment to another.
     *   Possible transitions are specified in as #InfectionTransition%s.
-    *   Considered points of times should have the distance dt and the last time point should be 0. 
+    *   Considered points of times should have the distance dt. The last time point determines the start time t0 of the simulation. 
     *   The time history must reach a certain point in the past so that the simulation can be performed.
     *   A warning is displayed if the condition is violated.
     * @param[in] N_init The population of the considered region.
@@ -98,8 +98,8 @@ public:
     *
     * The initialization method is selected automatically based on the different values that need to be set beforehand.
     * Infection compartments are always computed through historic flow.
-    * Initialization methods for susceptibles and recovered are tested in the following order:
-    * 1.) If a positive number for the total number of confirmed cases is set, recovered is set according to that value and #Susceptible%s are derived.
+    * Initialization methods for #Susceptible%s and recovered are tested in the following order:
+    * 1.) If a positive number for the total number of confirmed cases is set, #Recovered is set according to that value and #Susceptible%s are derived.
     * 2.) If #Susceptible%s are set, recovered will be derived.
     * 3.) If #Recovered are set directly, #Susceptible%s are derived.
     * 4.) If none of the above is set with positive value, the force of infection is used as in Messina et al (2021) to set the #Susceptible%s.
@@ -111,7 +111,7 @@ public:
     /**
     * @brief Computes number of Susceptibles for the current last time in m_populations.
     *
-    * Number is computed using previous number of Susceptibles and the force of infection (also from previous timestep).
+    * Number is computed using previous number of #Susceptible%s and the force of infection (also from previous timestep).
     * Number is stored at the matching index in m_populations.
     * @param[in] dt Time discretization step size.    
     */
@@ -141,7 +141,7 @@ public:
     void flows_current_timestep(ScalarType dt);
 
     /**
-     * @brief Computes total number of Deaths for the current last time in m_populations.
+     * @brief Computes total number of #Death%s for the current last time in m_populations.
      * 
      * Number is stored in m_populations.
      *
@@ -171,7 +171,7 @@ public:
      *              related to a flow from the considered #InfectionState to any other #InfectionState.
      *              This index is also used for related probability.
      * @param[in] idx_TransitionDistribution2 Specifies the index of the second relevant TransitionDistribution, 
-     *              related to a flow from the considered #InfectionState to any other #InfectionState (in most cases to Recovered). 
+     *              related to a flow from the considered #InfectionState to any other #InfectionState (in most cases to #Recovered). 
      *              Necessary related probability is calculated via 1-probability[idx_TransitionDistribution1].
      *              If the second index is not needed, eg if probability[idx_TransitionDistribution1]=1, 
      *              just use an arbitrary legal index.
@@ -190,7 +190,7 @@ public:
     void other_compartments_current_timestep(ScalarType dt);
 
     /**
-     * @brief Computes total number of Recovered for the current last time in m_populations.
+     * @brief Computes total number of #Recovered for the current last time in m_populations.
      * 
      * Number is stored in m_populations.
      *
@@ -233,7 +233,7 @@ public:
 private:
     ScalarType m_forceofinfection{0}; ///< Force of infection term needed for numerical scheme.
     ScalarType m_N{0}; ///< Total population size of the considered region.
-    ScalarType m_deaths_before{0}; ///< Total number of deaths at the time point - dt.
+    ScalarType m_deaths_before{0}; ///< Total number of deaths at the time point t0 - dt.
     ScalarType m_total_confirmed_cases{0}; ///< Total number of confirmed cases at time t0.
     ScalarType m_tol{1e-10}; ///< Tolerance used to calculate the maximum support of the TransitionDistributions.
     int m_initialization_method{

--- a/cpp/models/ide_secir/simulation.cpp
+++ b/cpp/models/ide_secir/simulation.cpp
@@ -59,10 +59,10 @@ void Simulation::advance(ScalarType tmax)
     }
 }
 
-TimeSeries<ScalarType> simulate(ScalarType t0, ScalarType tmax, ScalarType dt, Model const& m_model)
+TimeSeries<ScalarType> simulate(ScalarType tmax, ScalarType dt, Model const& m_model)
 {
     m_model.check_constraints(dt);
-    Simulation sim(m_model, t0, dt);
+    Simulation sim(m_model, dt);
     sim.advance(tmax);
     return sim.get_result();
 }

--- a/cpp/models/ide_secir/simulation.h
+++ b/cpp/models/ide_secir/simulation.h
@@ -44,12 +44,10 @@ public:
     /**
      * @brief setup the Simulation for an IDE model.
      * @param[in] model An instance of the IDE model.
-     * @param[in] t0 Start time.
      * @param[in] dt Step size of numerical solver.
      */
-    Simulation(Model const& model, ScalarType t0 = 0., ScalarType dt = 0.1)
+    Simulation(Model const& model, ScalarType dt = 0.1)
         : m_model(std::make_unique<Model>(model))
-        , m_t0(t0)
         , m_dt(dt)
     {
     }
@@ -107,15 +105,6 @@ public:
     }
 
     /**
-     * @brief get the starting time of the simulation.
-     * 
-     */
-    ScalarType get_t0()
-    {
-        return m_t0;
-    }
-
-    /**
      * @brief get the time step of the simulation.
      * 
      */
@@ -126,19 +115,17 @@ public:
 
 private:
     std::unique_ptr<Model> m_model; ///< Unique pointer to the Model simulated.
-    ScalarType m_t0; ///< Start time used for simulation.
     ScalarType m_dt; ///< Time step used for numerical computations in simulation.
 };
 
 /**
  * @brief simulates a compartmental model
- * @param[in] t0 start time
  * @param[in] tmax end time
  * @param[in] dt initial step size of integration
  * @param[in] model an instance of a compartmental model
  * @return a TimeSeries to represent the final simulation result
  */
-TimeSeries<ScalarType> simulate(double t0, double tmax, double dt, Model const& model);
+TimeSeries<ScalarType> simulate(double tmax, double dt, Model const& model);
 
 } // namespace isecir
 } // namespace mio

--- a/cpp/tests/test_ide_secir.cpp
+++ b/cpp/tests/test_ide_secir.cpp
@@ -103,7 +103,7 @@ public:
 // Check if population stays constant over course of simulation.
 TEST_F(ModelTestIdeSecir, checkPopulationConservation)
 {
-    mio::TimeSeries<ScalarType> compartments = simulate(0, 15, dt, *model);
+    mio::TimeSeries<ScalarType> compartments = simulate(15, dt, *model);
 
     ScalarType num_persons_before = 0.0;
     ScalarType num_persons_after  = 0.0;
@@ -120,7 +120,7 @@ TEST_F(ModelTestIdeSecir, checkPopulationConservation)
 TEST_F(ModelTestIdeSecir, compareWithPreviousRun)
 {
     auto compare                             = load_test_data_csv<ScalarType>("ide-secir-compare.csv");
-    mio::TimeSeries<ScalarType> compartments = simulate(0, 5, dt, *model);
+    mio::TimeSeries<ScalarType> compartments = simulate(5, dt, *model);
 
     ASSERT_EQ(compare.size(), static_cast<size_t>(compartments.get_num_time_points()));
     for (size_t i = 0; i < compare.size(); i++) {
@@ -137,7 +137,7 @@ TEST_F(ModelTestIdeSecir, compareWithPreviousRunTransitions)
 {
     auto compare = load_test_data_csv<ScalarType>("ide-secir-transitions-compare.csv");
 
-    mio::isecir::Simulation sim(*model, 0, dt);
+    mio::isecir::Simulation sim(*model, dt);
     sim.advance(5);
 
     auto transitions = sim.get_transitions();
@@ -218,7 +218,7 @@ TEST(IdeSecir, checkSimulationFunctions)
     model.parameters.set<mio::isecir::RiskOfInfectionFromSymptomatic>(prob);
 
     // Carry out simulation.
-    mio::isecir::Simulation sim(model, 0, dt);
+    mio::isecir::Simulation sim(model, dt);
     sim.advance(tmax);
     mio::TimeSeries<ScalarType> secihurd_simulated    = sim.get_result();
     mio::TimeSeries<ScalarType> transitions_simulated = sim.get_transitions();
@@ -275,7 +275,7 @@ TEST(IdeSecir, checkInitializations)
     EXPECT_EQ(0, model1.get_initialization_method());
 
     // Carry out simulation.
-    mio::isecir::Simulation sim1(model1, 0, dt);
+    mio::isecir::Simulation sim1(model1, dt);
     sim1.advance(tmax);
 
     // Verify that the expected initialization method was used.
@@ -296,7 +296,7 @@ TEST(IdeSecir, checkInitializations)
     model2.m_populations.get_last_value()[(Eigen::Index)mio::isecir::InfectionState::Recovered]   = 0;
 
     // Carry out simulation.
-    mio::isecir::Simulation sim2(model2, 0, dt);
+    mio::isecir::Simulation sim2(model2, dt);
     sim2.advance(tmax);
 
     // Verify that the expected initialization method was used.
@@ -310,7 +310,7 @@ TEST(IdeSecir, checkInitializations)
     model3.m_populations.get_last_value()[(Eigen::Index)mio::isecir::InfectionState::Recovered]   = 1000;
 
     // Carry out simulation.
-    mio::isecir::Simulation sim3(model3, 0, dt);
+    mio::isecir::Simulation sim3(model3, dt);
     sim3.advance(tmax);
 
     // Verify that the expected initialization method was used.
@@ -321,7 +321,7 @@ TEST(IdeSecir, checkInitializations)
     mio::isecir::Model model4(std::move(init_copy4), N, deaths, 0);
 
     // Carry out simulation.
-    mio::isecir::Simulation sim4(model4, 0, dt);
+    mio::isecir::Simulation sim4(model4, dt);
     sim4.advance(tmax);
 
     // Verify that the expected initialization method was used.
@@ -338,7 +338,7 @@ TEST(IdeSecir, checkInitializations)
     model5.m_populations.get_last_value()[(Eigen::Index)mio::isecir::InfectionState::Recovered]   = 0;
 
     // Carry out simulation.
-    mio::isecir::Simulation sim5(model5, 0, dt);
+    mio::isecir::Simulation sim5(model5, dt);
     sim5.advance(tmax);
 
     // Verify that initialization was not possible with one of the models methods.
@@ -354,7 +354,7 @@ TEST(IdeSecir, checkInitializations)
     model6.m_populations.get_last_value()[(Eigen::Index)mio::isecir::InfectionState::Recovered]   = 0;
 
     // Carry out simulation.
-    mio::isecir::Simulation sim6(model6, 0, dt);
+    mio::isecir::Simulation sim6(model6, dt);
     sim6.advance(tmax);
 
     // Verify that initialization was possible but the result is not appropriate.
@@ -666,7 +666,7 @@ TEST(IdeSecir, checkProportionRecoveredDeath)
     model.parameters.set<mio::isecir::RiskOfInfectionFromSymptomatic>(prob);
 
     // Carry out simulation.
-    mio::isecir::Simulation sim(model, 0, dt);
+    mio::isecir::Simulation sim(model, dt);
     sim.advance(tmax);
     mio::TimeSeries<ScalarType> secihurd_simulated = sim.get_result();
 
@@ -774,11 +774,11 @@ TEST(IdeSecir, compareEquilibria)
     model2.parameters.set<mio::isecir::RiskOfInfectionFromSymptomatic>(prob);
 
     // Carry out simulation.
-    mio::isecir::Simulation sim(model, 0, dt);
+    mio::isecir::Simulation sim(model, dt);
     sim.advance(tmax);
     mio::TimeSeries<ScalarType> secihurd_simulated = sim.get_result();
 
-    mio::isecir::Simulation sim2(model2, 0, dt);
+    mio::isecir::Simulation sim2(model2, dt);
     sim2.advance(tmax);
     mio::TimeSeries<ScalarType> secihurd_simulated2 = sim2.get_result();
 


### PR DESCRIPTION
# Changes and Information

- The start time of the simulation is not assumed to be zero anymore but is determined by the initial flows given as input to the model. 

## Merge Request - Guideline Checklist

Please check our [git workflow](https://github.com/SciCompMod/memilio/wiki/git-workflow). Use the **draft** feature if the Pull Request is not yet ready to review.

### Checks by code author

- [ ] Every addressed issue is linked (use the "Closes #ISSUE" keyword below)
- [ ] New code adheres to [coding guidelines](https://github.com/SciCompMod/memilio/wiki/Coding-guidelines)
- [ ] No large data files have been added (files should in sum not exceed 100 KB, avoid PDFs, Word docs, etc.)
- [ ] Tests are added for new functionality and a local test run was successful (with and without OpenMP)
- [ ] Appropriate **documentation** for new functionality has been added (Doxygen in the code and Markdown files if necessary)
- [ ] Proper attention to licenses, especially no new third-party software with conflicting license has been added
- [ ] (For ABM development) Checked [benchmark results](https://github.com/SciCompMod/memilio/wiki/Agent-Based-Model-Development) and ran and posted a local test above from before and after development to ensure performance is monitored.

### Checks by code reviewer(s)

- [ ] Corresponding issue(s) is/are linked and addressed
- [ ] Code is clean of development artifacts (no deactivated or commented code lines, no debugging printouts, etc.)
- [ ] Appropriate **unit tests** have been added, CI passes, code coverage and performance is acceptable (did not decrease)
- [ ] No large data files added in the whole history of commits(files should in sum not exceed 100 KB, avoid PDFs, Word docs, etc.)
- [ ] On merge, add 2-5 lines with the changes (main added features, changed items, or corrected bugs) to the merge-commit-message. This can be taken from the **briefly-list-the-changes** above (best case) or the separate commit messages (worst case).

Closes #977 
