### PR TITLE
988 info on sucessful adaptive step sizing is also shown for fixed step size integrators

### DIFF
--- a/cpp/memilio/math/floating_point.h
+++ b/cpp/memilio/math/floating_point.h
@@ -110,7 +110,7 @@ bool floating_point_greater(T v1, T v2, T abs_tol = 0, T rel_tol = std::numeric_
 template <class T>
 bool floating_point_less_equal(T v1, T v2, T abs_tol = 0, T rel_tol = std::numeric_limits<T>::min())
 {
-    return !floating_point_less(v2, v1, abs_tol, rel_tol);
+    return !floating_point_greater(v2, v1, abs_tol, rel_tol);
 }
 
 /**

--- a/cpp/memilio/math/integrator.h
+++ b/cpp/memilio/math/integrator.h
@@ -78,6 +78,7 @@ public:
      */
     OdeIntegrator(std::shared_ptr<IntegratorCore> core)
         : m_core(core)
+        , m_is_adaptive(false)
     {
     }
 
@@ -95,11 +96,13 @@ public:
 
     void set_integrator(std::shared_ptr<IntegratorCore> integrator)
     {
-        m_core = integrator;
+        m_core        = integrator;
+        m_is_adaptive = false;
     }
 
 private:
     std::shared_ptr<IntegratorCore> m_core;
+    bool m_is_adaptive;
 };
 
 } // namespace mio


### PR DESCRIPTION
# Changes and Information

Please **briefly list the changes** (main added features, changed items, or corrected bugs) made:

- Check whether an IntegratorCore is adaptive in OdeIntegrator::advance.
- Fix floating_point_less_equal.

If need be, add additional information and what the reviewer should look out for in particular:

- Checks only whether dt changes during m_core->step calls. After only one change, register m_core as adaptive.
- The result "m_is_adaptive" is stored in OdeIntegrator, and it is only reset (to false) whenever m_core is set.
  - This may prevent under-reporting, e.g. when advance is called repeatedly with `dt == dt_max` while the ODE admits a larger step size.
  - While currently not possible, this may cause over-reporting if an adaptive m_core were to be configured to be non-adaptive in between advance calls. I think this is acceptable.
- I changed the while loop to a for loop to have the loop statement in one place. This only changes the scope of `i`. I you prefer the while loop for any reason, I will undo this change.
- I spotted that `floating_point_less_equal` returned  `!floating_point_less` and corrected it to `!floating_point_greater`.

## Merge Request - Guideline Checklist

Please check our [git workflow](https://github.com/SciCompMod/memilio/wiki/git-workflow). Use the **draft** feature if the Pull Request is not yet ready to review.

### Checks by code author

- [x] Every addressed issue is linked (use the "Closes #ISSUE" keyword below)
- [x] New code adheres to [coding guidelines](https://github.com/SciCompMod/memilio/wiki/Coding-guidelines)
- [x] No large data files have been added (files should in sum not exceed 100 KB, avoid PDFs, Word docs, etc.)
- [x] Tests are added for new functionality and a local test run was successful (with and without OpenMP)
- [x] Appropriate **documentation** for new functionality has been added (Doxygen in the code and Markdown files if necessary)
- [x] Proper attention to licenses, especially no new third-party software with conflicting license has been added
- [x] (For ABM development) Checked [benchmark results](https://github.com/SciCompMod/memilio/wiki/Agent-Based-Model-Development) and ran and posted a local test above from before and after development to ensure performance is monitored.

### Checks by code reviewer(s)

- [ ] Corresponding issue(s) is/are linked and addressed
- [ ] Code is clean of development artifacts (no deactivated or commented code lines, no debugging printouts, etc.)
- [ ] Appropriate **unit tests** have been added, CI passes, code coverage and performance is acceptable (did not decrease)
- [ ] No large data files added in the whole history of commits(files should in sum not exceed 100 KB, avoid PDFs, Word docs, etc.)
- [ ] On merge, add 2-5 lines with the changes (main added features, changed items, or corrected bugs) to the merge-commit-message. This can be taken from the **briefly-list-the-changes** above (best case) or the separate commit messages (worst case).

Closes #988 