### PR TITLE
997 Resolve size_t underflow while removing dublicates in dynamic NPIs by using int

### DIFF
--- a/cpp/memilio/epidemiology/dynamic_npis.h
+++ b/cpp/memilio/epidemiology/dynamic_npis.h
@@ -320,7 +320,7 @@ void implement_dynamic_npis(DampingExprGroup& damping_expr_group, const std::vec
     for (auto& damping_expr : damping_expr_group) {
         //go from the back so indices aren't invalidated when dampings are removed
         //use indices to loop instead of reverse iterators because removing invalidates the current iterator
-        for (auto i = size_t(0); i < damping_expr.get_dampings().size() - 1; ++i) {
+        for (auto i = int(0); i < int(damping_expr.get_dampings().size()) - 1; ++i) {
             auto it = damping_expr.get_dampings().rbegin() + i;
 
             //look for previous damping of the same type/level


### PR DESCRIPTION
# Changes and Information

Please **briefly list the changes** (main added features, changed items, or corrected bugs) made:

- If damping_expr.get_dampings().size()  == 0, then damping_expr.get_dampings().size()  - 1 becomes a very large positive number, not -1

## Merge Request - Guideline Checklist

Please check our [git workflow](https://github.com/SciCompMod/memilio/wiki/git-workflow). Use the **draft** feature if the Pull Request is not yet ready to review.

### Checks by code author

- [x] Every addressed issue is linked (use the "Closes #ISSUE" keyword below)
- [x] New code adheres to [coding guidelines](https://github.com/SciCompMod/memilio/wiki/Coding-guidelines)
- [x] No large data files have been added (files should in sum not exceed 100 KB, avoid PDFs, Word docs, etc.)
- [x] Tests are added for new functionality and a local test run was successful (with and without OpenMP)
- [x] Appropriate **documentation** for new functionality has been added (Doxygen in the code and Markdown files if necessary)
- [x] Proper attention to licenses, especially no new third-party software with conflicting license has been added
- [ ] (For ABM development) Checked [benchmark results](https://github.com/SciCompMod/memilio/wiki/Agent-Based-Model-Development) and ran and posted a local test above from before and after development to ensure performance is monitored.

### Checks by code reviewer(s)

- [x] Corresponding issue(s) is/are linked and addressed
- [x] Code is clean of development artifacts (no deactivated or commented code lines, no debugging printouts, etc.)
- [x] Appropriate **unit tests** have been added, CI passes, code coverage and performance is acceptable (did not decrease)
- [x] No large data files added in the whole history of commits(files should in sum not exceed 100 KB, avoid PDFs, Word docs, etc.)
- [x] On merge, add 2-5 lines with the changes (main added features, changed items, or corrected bugs) to the merge-commit-message. This can be taken from the **briefly-list-the-changes** above (best case) or the separate commit messages (worst case).
