### PR TITLE
965 use int instead of unsigned int in lct infection state

### DIFF
--- a/cpp/examples/lct_secir.cpp
+++ b/cpp/examples/lct_secir.cpp
@@ -47,25 +47,25 @@ int main()
                                                                 {50},  {10, 10, 5, 3, 2}, {20},         {10}};
 
     // Assert that initial_populations has the right shape.
-    if (initial_populations.size() != (int)LctState::InfectionState::Count) {
+    if ((int)initial_populations.size() != (int)LctState::InfectionState::Count) {
         mio::log_error("The number of vectors in initial_populations does not match the number of InfectionStates.");
         return 1;
     }
-    if ((initial_populations[(int)LctState::InfectionState::Susceptible].size() !=
+    if (((int)initial_populations[(int)LctState::InfectionState::Susceptible].size() !=
          LctState::get_num_subcompartments<LctState::InfectionState::Susceptible>()) ||
-        (initial_populations[(int)LctState::InfectionState::Exposed].size() !=
+        ((int)initial_populations[(int)LctState::InfectionState::Exposed].size() !=
          LctState::get_num_subcompartments<LctState::InfectionState::Exposed>()) ||
-        (initial_populations[(int)LctState::InfectionState::InfectedNoSymptoms].size() !=
+        ((int)initial_populations[(int)LctState::InfectionState::InfectedNoSymptoms].size() !=
          LctState::get_num_subcompartments<LctState::InfectionState::InfectedNoSymptoms>()) ||
-        (initial_populations[(int)LctState::InfectionState::InfectedSymptoms].size() !=
+        ((int)initial_populations[(int)LctState::InfectionState::InfectedSymptoms].size() !=
          LctState::get_num_subcompartments<LctState::InfectionState::InfectedSymptoms>()) ||
-        (initial_populations[(int)LctState::InfectionState::InfectedSevere].size() !=
+        ((int)initial_populations[(int)LctState::InfectionState::InfectedSevere].size() !=
          LctState::get_num_subcompartments<LctState::InfectionState::InfectedSevere>()) ||
-        (initial_populations[(int)LctState::InfectionState::InfectedCritical].size() !=
+        ((int)initial_populations[(int)LctState::InfectionState::InfectedCritical].size() !=
          LctState::get_num_subcompartments<LctState::InfectionState::InfectedCritical>()) ||
-        (initial_populations[(int)LctState::InfectionState::Recovered].size() !=
+        ((int)initial_populations[(int)LctState::InfectionState::Recovered].size() !=
          LctState::get_num_subcompartments<LctState::InfectionState::Recovered>()) ||
-        (initial_populations[(int)LctState::InfectionState::Dead].size() !=
+        ((int)initial_populations[(int)LctState::InfectionState::Dead].size() !=
          LctState::get_num_subcompartments<LctState::InfectionState::Dead>())) {
         mio::log_error("The length of at least one vector in initial_populations does not match the related number of "
                        "subcompartments.");
@@ -74,32 +74,31 @@ int main()
 
     // Transfer the initial values in initial_populations to the vector init.
     Eigen::VectorXd init = Eigen::VectorXd::Zero(LctState::Count);
-    init[(int)LctState::get_first_index<LctState::InfectionState::Susceptible>()] =
+    init[LctState::get_first_index<LctState::InfectionState::Susceptible>()] =
         initial_populations[(int)LctState::InfectionState::Susceptible][0];
-    for (unsigned int i = 0; i < LctState::get_num_subcompartments<LctState::InfectionState::Exposed>(); i++) {
-        init[(int)LctState::get_first_index<LctState::InfectionState::Exposed>() + i] =
+    for (int i = 0; i < LctState::get_num_subcompartments<LctState::InfectionState::Exposed>(); i++) {
+        init[LctState::get_first_index<LctState::InfectionState::Exposed>() + i] =
             initial_populations[(int)LctState::InfectionState::Exposed][i];
     }
-    for (unsigned int i = 0; i < LctState::get_num_subcompartments<LctState::InfectionState::InfectedNoSymptoms>();
-         i++) {
-        init[(int)LctState::get_first_index<LctState::InfectionState::InfectedNoSymptoms>() + i] =
+    for (int i = 0; i < LctState::get_num_subcompartments<LctState::InfectionState::InfectedNoSymptoms>(); i++) {
+        init[LctState::get_first_index<LctState::InfectionState::InfectedNoSymptoms>() + i] =
             initial_populations[(int)LctState::InfectionState::InfectedNoSymptoms][i];
     }
-    for (unsigned int i = 0; i < LctState::get_num_subcompartments<LctState::InfectionState::InfectedSymptoms>(); i++) {
-        init[(int)LctState::get_first_index<LctState::InfectionState::InfectedSymptoms>() + i] =
+    for (int i = 0; i < LctState::get_num_subcompartments<LctState::InfectionState::InfectedSymptoms>(); i++) {
+        init[LctState::get_first_index<LctState::InfectionState::InfectedSymptoms>() + i] =
             initial_populations[(int)LctState::InfectionState::InfectedSymptoms][i];
     }
-    for (unsigned int i = 0; i < LctState::get_num_subcompartments<LctState::InfectionState::InfectedSevere>(); i++) {
-        init[(int)LctState::get_first_index<LctState::InfectionState::InfectedSevere>() + i] =
+    for (int i = 0; i < LctState::get_num_subcompartments<LctState::InfectionState::InfectedSevere>(); i++) {
+        init[LctState::get_first_index<LctState::InfectionState::InfectedSevere>() + i] =
             initial_populations[(int)LctState::InfectionState::InfectedSevere][i];
     }
-    for (unsigned int i = 0; i < LctState::get_num_subcompartments<LctState::InfectionState::InfectedCritical>(); i++) {
-        init[(int)LctState::get_first_index<LctState::InfectionState::InfectedCritical>() + i] =
+    for (int i = 0; i < LctState::get_num_subcompartments<LctState::InfectionState::InfectedCritical>(); i++) {
+        init[LctState::get_first_index<LctState::InfectionState::InfectedCritical>() + i] =
             initial_populations[(int)LctState::InfectionState::InfectedCritical][i];
     }
-    init[(int)LctState::get_first_index<LctState::InfectionState::Recovered>()] =
+    init[LctState::get_first_index<LctState::InfectionState::Recovered>()] =
         initial_populations[(int)LctState::InfectionState::Recovered][0];
-    init[(int)LctState::get_first_index<LctState::InfectionState::Dead>()] =
+    init[LctState::get_first_index<LctState::InfectionState::Dead>()] =
         initial_populations[(int)LctState::InfectionState::Dead][0];
 
     // Initialize model.

--- a/cpp/examples/lct_secir.cpp
+++ b/cpp/examples/lct_secir.cpp
@@ -47,26 +47,26 @@ int main()
                                                                 {50},  {10, 10, 5, 3, 2}, {20},         {10}};
 
     // Assert that initial_populations has the right shape.
-    if ((int)initial_populations.size() != (int)LctState::InfectionState::Count) {
+    if (initial_populations.size() != (size_t)LctState::InfectionState::Count) {
         mio::log_error("The number of vectors in initial_populations does not match the number of InfectionStates.");
         return 1;
     }
-    if (((int)initial_populations[(int)LctState::InfectionState::Susceptible].size() !=
-         LctState::get_num_subcompartments<LctState::InfectionState::Susceptible>()) ||
-        ((int)initial_populations[(int)LctState::InfectionState::Exposed].size() !=
-         LctState::get_num_subcompartments<LctState::InfectionState::Exposed>()) ||
-        ((int)initial_populations[(int)LctState::InfectionState::InfectedNoSymptoms].size() !=
-         LctState::get_num_subcompartments<LctState::InfectionState::InfectedNoSymptoms>()) ||
-        ((int)initial_populations[(int)LctState::InfectionState::InfectedSymptoms].size() !=
-         LctState::get_num_subcompartments<LctState::InfectionState::InfectedSymptoms>()) ||
-        ((int)initial_populations[(int)LctState::InfectionState::InfectedSevere].size() !=
-         LctState::get_num_subcompartments<LctState::InfectionState::InfectedSevere>()) ||
-        ((int)initial_populations[(int)LctState::InfectionState::InfectedCritical].size() !=
-         LctState::get_num_subcompartments<LctState::InfectionState::InfectedCritical>()) ||
-        ((int)initial_populations[(int)LctState::InfectionState::Recovered].size() !=
-         LctState::get_num_subcompartments<LctState::InfectionState::Recovered>()) ||
-        ((int)initial_populations[(int)LctState::InfectionState::Dead].size() !=
-         LctState::get_num_subcompartments<LctState::InfectionState::Dead>())) {
+    if ((initial_populations[(int)LctState::InfectionState::Susceptible].size() !=
+         (size_t)LctState::get_num_subcompartments<LctState::InfectionState::Susceptible>()) ||
+        (initial_populations[(int)LctState::InfectionState::Exposed].size() !=
+         (size_t)LctState::get_num_subcompartments<LctState::InfectionState::Exposed>()) ||
+        (initial_populations[(int)LctState::InfectionState::InfectedNoSymptoms].size() !=
+         (size_t)LctState::get_num_subcompartments<LctState::InfectionState::InfectedNoSymptoms>()) ||
+        (initial_populations[(int)LctState::InfectionState::InfectedSymptoms].size() !=
+         (size_t)LctState::get_num_subcompartments<LctState::InfectionState::InfectedSymptoms>()) ||
+        (initial_populations[(int)LctState::InfectionState::InfectedSevere].size() !=
+         (size_t)LctState::get_num_subcompartments<LctState::InfectionState::InfectedSevere>()) ||
+        (initial_populations[(int)LctState::InfectionState::InfectedCritical].size() !=
+         (size_t)LctState::get_num_subcompartments<LctState::InfectionState::InfectedCritical>()) ||
+        (initial_populations[(int)LctState::InfectionState::Recovered].size() !=
+         (size_t)LctState::get_num_subcompartments<LctState::InfectionState::Recovered>()) ||
+        (initial_populations[(int)LctState::InfectionState::Dead].size() !=
+         (size_t)LctState::get_num_subcompartments<LctState::InfectionState::Dead>())) {
         mio::log_error("The length of at least one vector in initial_populations does not match the related number of "
                        "subcompartments.");
         return 1;

--- a/cpp/memilio/epidemiology/lct_infection_state.h
+++ b/cpp/memilio/epidemiology/lct_infection_state.h
@@ -36,7 +36,7 @@ class LctInfectionState
 {
 public:
     using InfectionState = InfectionStates;
-    static_assert((int)InfectionState::Count == sizeof...(Ns),
+    static_assert((size_t)InfectionState::Count == sizeof...(Ns),
                   "The number of integers provided as template parameters must be "
                   "the same as the entry Count of InfectionState.");
 
@@ -46,7 +46,7 @@ public:
      * @brief Gets the number of subcompartments in an infection state.
      *
      * @tparam State: Infection state for which the number of subcompartments should be returned.   
-     * @return Number of subcompartments for State.
+     * @return Number of subcompartments for State. Returned value is always at least one.
      */
     template <InfectionState State>
     static constexpr int get_num_subcompartments()
@@ -61,7 +61,8 @@ public:
      * In a simulation, the number of individuals in the subcompartments are stored in vectors. 
      * Accordingly, the index of the first subcompartment of State in such a vector is returned.
      * @tparam State: Infection state for which the index should be returned.    
-     * @return Index of the first subcompartment for a vector with one entry per subcompartment.
+     * @return Index of the first subcompartment for a vector with one entry per subcompartment. 
+     *      Returned value is always non-negative.
      */
     template <InfectionState State>
     static constexpr int get_first_index()

--- a/cpp/memilio/epidemiology/lct_infection_state.h
+++ b/cpp/memilio/epidemiology/lct_infection_state.h
@@ -31,12 +31,12 @@ namespace mio
  * @tparam Ns Number of subcompartments for each infection state defined in InfectionState. 
  *      The number of given template arguments must be equal to the entry Count from InfectionState.
  */
-template <class InfectionStates, unsigned int... Ns>
+template <class InfectionStates, int... Ns>
 class LctInfectionState
 {
 public:
     using InfectionState = InfectionStates;
-    static_assert((unsigned int)InfectionState::Count == sizeof...(Ns),
+    static_assert((int)InfectionState::Count == sizeof...(Ns),
                   "The number of integers provided as template parameters must be "
                   "the same as the entry Count of InfectionState.");
 
@@ -49,7 +49,7 @@ public:
      * @return Number of subcompartments for State.
      */
     template <InfectionState State>
-    static constexpr unsigned int get_num_subcompartments()
+    static constexpr int get_num_subcompartments()
     {
         static_assert(State < InfectionState::Count, "State must be a a valid InfectionState.");
         return m_subcompartment_numbers[(int)State];
@@ -64,20 +64,20 @@ public:
      * @return Index of the first subcompartment for a vector with one entry per subcompartment.
      */
     template <InfectionState State>
-    static constexpr unsigned int get_first_index()
+    static constexpr int get_first_index()
     {
         static_assert(State < InfectionState::Count, "State must be a a valid InfectionState.");
-        unsigned int index = 0;
+        int index = 0;
         for (int i = 0; i < (int)(State); i++) {
             index = index + m_subcompartment_numbers[i];
         }
         return index;
     }
 
-    static constexpr unsigned int Count{(... + Ns)};
+    static constexpr int Count{(... + Ns)};
 
 private:
-    static constexpr const std::array<unsigned int, sizeof...(Ns)> m_subcompartment_numbers{
+    static constexpr const std::array<int, sizeof...(Ns)> m_subcompartment_numbers{
         Ns...}; ///< Vector which defines the number of subcompartments for each infection state of InfectionState.
 };
 

--- a/cpp/models/lct_secir/model.h
+++ b/cpp/models/lct_secir/model.h
@@ -43,8 +43,8 @@ namespace lsecir
  * @tparam NumInfectedSevere The number of subcompartents used for the InfectedSevere compartment.
  * @tparam NumInfectedCritical The number of subcompartents used for the InfectedCritical compartment.
  */
-template <unsigned int NumExposed, unsigned int NumInfectedNoSymptoms, unsigned int NumInfectedSymptoms,
-          unsigned int NumInfectedSevere, unsigned int NumInfectedCritical>
+template <int NumExposed, int NumInfectedNoSymptoms, int NumInfectedSymptoms, int NumInfectedSevere,
+          int NumInfectedCritical>
 class Model
 {
 
@@ -75,7 +75,7 @@ public:
             log_error("Size of the initial values does not match subcompartments.");
             return true;
         }
-        for (unsigned int i = 0; i < LctState::Count; i++) {
+        for (int i = 0; i < LctState::Count; i++) {
             if (m_initial_values[i] < 0) {
                 log_warning(
                     "Initial values for one subcompartment are less than zero. Simulation results are not realistic.");
@@ -291,7 +291,7 @@ public:
     void set_initial_values(Eigen::VectorXd init)
     {
         m_initial_values = init;
-        m_N0 = m_initial_values.sum();
+        m_N0             = m_initial_values.sum();
     }
 
     Parameters parameters{}; ///< Parameters of the model.

--- a/cpp/models/lct_secir/parameters_io.h
+++ b/cpp/models/lct_secir/parameters_io.h
@@ -118,8 +118,8 @@ IOResult<void> set_initial_data_from_confirmed_cases(Model& model, const std::st
                 int idxInfectedNoSymptoms_last =
                     LctState::template get_first_index<InfectionState::InfectedNoSymptoms>() +
                     LctState::template get_num_subcompartments<InfectionState::InfectedNoSymptoms>() - 1;
-                for (int i = 0;
-                     i < (int)LctState::template get_num_subcompartments<InfectionState::InfectedNoSymptoms>(); i++) {
+                for (int i = 0; i < LctState::template get_num_subcompartments<InfectionState::InfectedNoSymptoms>();
+                     i++) {
                     if (offset == std::floor(i * timeInfectedNoSymptoms_i)) {
                         init[idxInfectedNoSymptoms_last - i] -=
                             (1 - (i * timeInfectedNoSymptoms_i - std::floor(i * timeInfectedNoSymptoms_i))) *
@@ -152,7 +152,7 @@ IOResult<void> set_initial_data_from_confirmed_cases(Model& model, const std::st
                 // Index of the last subcompartment of Exposed.
                 int idxExposed_last = LctState::template get_first_index<InfectionState::Exposed>() +
                                       LctState::template get_num_subcompartments<InfectionState::Exposed>() - 1;
-                for (int i = 0; i < (int)LctState::template get_num_subcompartments<InfectionState::Exposed>(); i++) {
+                for (int i = 0; i < LctState::template get_num_subcompartments<InfectionState::Exposed>(); i++) {
                     if (offset == std::floor(timeInfectedNoSymptoms + i * timeExposed_i)) {
                         init[idxExposed_last - i] -= (1 - (timeInfectedNoSymptoms + i * timeExposed_i -
                                                            std::floor(timeInfectedNoSymptoms + i * timeExposed_i))) *
@@ -185,7 +185,7 @@ IOResult<void> set_initial_data_from_confirmed_cases(Model& model, const std::st
                     (ScalarType)LctState::template get_num_subcompartments<InfectionState::InfectedSymptoms>();
                 // Index of the first subcompartment of InfectedSymptoms.
                 int idxInfectedSymptoms_first = LctState::template get_first_index<InfectionState::InfectedSymptoms>();
-                for (int i = 0; i < (int)LctState::template get_num_subcompartments<InfectionState::InfectedSymptoms>();
+                for (int i = 0; i < LctState::template get_num_subcompartments<InfectionState::InfectedSymptoms>();
                      i++) {
                     if (offset == std::floor(-timeInfectedSymptoms_i * (i + 1))) {
                         init[idxInfectedSymptoms_first + i] -=
@@ -221,8 +221,7 @@ IOResult<void> set_initial_data_from_confirmed_cases(Model& model, const std::st
                 ScalarType prob_SeverePerInfectedSymptoms = model.parameters.template get<SeverePerInfectedSymptoms>();
                 // Index of the first subcompartment of InfectedSevere.
                 int idxInfectedSevere_first = LctState::template get_first_index<InfectionState::InfectedSevere>();
-                for (int i = 0; i < (int)LctState::template get_num_subcompartments<InfectionState::InfectedSevere>();
-                     i++) {
+                for (int i = 0; i < LctState::template get_num_subcompartments<InfectionState::InfectedSevere>(); i++) {
                     if (offset == std::floor(-timeInfectedSymptoms - timeInfectedSevere_i * (i + 1))) {
                         init[idxInfectedSevere_first + i] -=
                             prob_SeverePerInfectedSymptoms *
@@ -265,7 +264,7 @@ IOResult<void> set_initial_data_from_confirmed_cases(Model& model, const std::st
                 ScalarType prob_CriticalPerSevere         = model.parameters.template get<CriticalPerSevere>();
                 // Index of the first subcompartment of InfectedCritical.
                 int idxInfectedCritical_first = LctState::template get_first_index<InfectionState::InfectedCritical>();
-                for (int i = 0; i < (int)LctState::template get_num_subcompartments<InfectionState::InfectedCritical>();
+                for (int i = 0; i < LctState::template get_num_subcompartments<InfectionState::InfectedCritical>();
                      i++) {
                     if (offset ==
                         std::floor(-timeInfectedSymptoms - timeInfectedSevere - timeInfectedCritical_i * (i + 1))) {

--- a/cpp/tests/test_lct_parameters_io.cpp
+++ b/cpp/tests/test_lct_parameters_io.cpp
@@ -67,7 +67,7 @@ TEST(TestLCTParametersIo, ReadPopulationDataRKI)
     Eigen::VectorXd compare(LctState::Count);
     compare << 863.05, 14.30625, 8.53125, 30.1125, 36.1875, 3.8125, 9.88, 3.52, 0.09, 0.25, 0.6888, 27.8712, 1.7;
 
-    for (unsigned int i = 0; i < LctState::Count; i++) {
+    for (int i = 0; i < LctState::Count; i++) {
         EXPECT_NEAR(model.get_initial_values()[i], compare[i], 1e-4) << "at subcompartment number " << i;
     }
 }

--- a/cpp/tests/test_lct_secir.cpp
+++ b/cpp/tests/test_lct_secir.cpp
@@ -226,7 +226,7 @@ TEST(TestLCTSecir, testEvalRightHandSide)
     model.parameters.get<mio::lsecir::DeathsPerCritical>()              = 0.3;
 
     // Compare the result of eval_right_hand_side() with a hand calculated result.
-    unsigned int num_subcompartments = LctState::Count;
+    int num_subcompartments = LctState::Count;
     Eigen::VectorXd dydt(num_subcompartments);
     model.eval_right_hand_side(model.get_initial_values(), 0, dydt);
 
@@ -234,7 +234,7 @@ TEST(TestLCTSecir, testEvalRightHandSide)
     compare << -15.3409, -3.4091, 6.25, -17.5, 15, 0, 3.3052, 3.4483, -7.0417, 6.3158, -2.2906, -2.8169, 12.3899,
         1.6901;
 
-    for (unsigned int i = 0; i < num_subcompartments; i++) {
+    for (int i = 0; i < num_subcompartments; i++) {
         ASSERT_NEAR(compare[i], dydt[i], 1e-3);
     }
 }
@@ -460,17 +460,17 @@ TEST(TestLCTSecir, testConstraints)
     using LctState = Model::LctState;
 
     // Check wrong size of initial value vector.
-    Model model1(std::move(Eigen::VectorXd::Ones((int)LctState::Count - 1)), std::move(parameters_lct));
+    Model model1(std::move(Eigen::VectorXd::Ones(LctState::Count - 1)), std::move(parameters_lct));
     constraint_check = model1.check_constraints();
     EXPECT_TRUE(constraint_check);
 
     // Check with values smaller than zero.
-    Model model2(std::move(Eigen::VectorXd::Constant((int)LctState::Count, -1)), std::move(parameters_lct));
+    Model model2(std::move(Eigen::VectorXd::Constant(LctState::Count, -1)), std::move(parameters_lct));
     constraint_check = model2.check_constraints();
     EXPECT_TRUE(constraint_check);
 
     // Check with correct conditions.
-    Model model3(std::move(Eigen::VectorXd::Constant((int)LctState::Count, 1)));
+    Model model3(std::move(Eigen::VectorXd::Constant(LctState::Count, 1)));
     constraint_check = model3.check_constraints();
     EXPECT_FALSE(constraint_check);
 


### PR DESCRIPTION
# Changes and Information

Please **briefly list the changes** (main added features, changed items, or corrected bugs) made:

- Ints instead of unsigned ints are now used in the LctInfectionState class.
-
-


If need be, add additional information and what the reviewer should look out for in particular:

-
-

## Merge Request - Guideline Checklist

Please check our [git workflow](https://github.com/SciCompMod/memilio/wiki/git-workflow). Use the **draft** feature if the Pull Request is not yet ready to review.

### Checks by code author

- [x] Every addressed issue is linked (use the "Closes #ISSUE" keyword below)
- [x] New code adheres to [coding guidelines](https://github.com/SciCompMod/memilio/wiki/Coding-guidelines)
- [x] No large data files have been added (files should in sum not exceed 100 KB, avoid PDFs, Word docs, etc.)
- [x] Tests are added for new functionality and a local test run was successful (with and without OpenMP)
- [x] Appropriate **documentation** for new functionality has been added (Doxygen in the code and Markdown files if necessary)
- [x] Proper attention to licenses, especially no new third-party software with conflicting license has been added
- [ ] (For ABM development) Checked [benchmark results](https://github.com/SciCompMod/memilio/wiki/Agent-Based-Model-Development) and ran and posted a local test above from before and after development to ensure performance is monitored.

### Checks by code reviewer(s)

- [ ] Corresponding issue(s) is/are linked and addressed
- [ ] Code is clean of development artifacts (no deactivated or commented code lines, no debugging printouts, etc.)
- [ ] Appropriate **unit tests** have been added, CI passes, code coverage and performance is acceptable (did not decrease)
- [ ] No large data files added in the whole history of commits(files should in sum not exceed 100 KB, avoid PDFs, Word docs, etc.)
- [ ] On merge, add 2-5 lines with the changes (main added features, changed items, or corrected bugs) to the merge-commit-message. This can be taken from the **briefly-list-the-changes** above (best case) or the separate commit messages (worst case).

Closes #965 