### PR TITLE
992 download boost libs with URL instead of git repo

### DIFF
--- a/cpp/thirdparty/CMakeLists.txt
+++ b/cpp/thirdparty/CMakeLists.txt
@@ -66,40 +66,21 @@ endif()
 
 # ## BOOST
 if(MEMILIO_USE_BUNDLED_BOOST)
-    message(STATUS "Downloading Boost library. This may take several minutes. This is the time to get yourself a coffee. :-)")
+    message(STATUS "Downloading Boost library")
+
+    string(REPLACE "." "_" MEMILIO_BOOST_VERSION_UNDERSC "${MEMILIO_BOOST_VERSION}")
 
     include(FetchContent)
     FetchContent_Declare(boost
-    GIT_REPOSITORY https://github.com/boostorg/boost.git
-    GIT_TAG boost-${MEMILIO_BOOST_VERSION})
+        #don't use the URL from github, that download isn't complete and requires more setup (subrepositories, bootstrapping)
+        URL https://archives.boost.io/release/${MEMILIO_BOOST_VERSION}/source/boost_${MEMILIO_BOOST_VERSION_UNDERSC}.tar.gz
+    )
     FetchContent_GetProperties(boost)
 
     if(NOT boost_POPULATED)
         FetchContent_Populate(boost)
     endif()
-    
-    add_custom_target(boost-bootstrap ALL 
-            DEPENDS "${boost_SOURCE_DIR}/boost"
-            )
 
-    if(MSVC)
-        add_custom_command(
-            OUTPUT "${boost_SOURCE_DIR}/boost"
-            COMMAND "bootstrap.bat"
-            COMMAND "b2.exe" headers
-            WORKING_DIRECTORY ${boost_SOURCE_DIR}
-            VERBATIM
-            )
-    else()
-        add_custom_command(
-            OUTPUT "${boost_SOURCE_DIR}/boost"
-            COMMAND ./bootstrap.sh
-            COMMAND ./b2 headers 
-            WORKING_DIRECTORY ${boost_SOURCE_DIR}
-            VERBATIM
-            )
-    endif()
-    
     add_library(boost INTERFACE)
     add_dependencies(boost boost-bootstrap)
     add_library(Boost::boost ALIAS boost)

--- a/pycode/memilio-generation/CMakeLists.txt
+++ b/pycode/memilio-generation/CMakeLists.txt
@@ -13,8 +13,6 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # add in C++ library
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../../cpp ${CMAKE_CURRENT_BINARY_DIR}/cpp EXCLUDE_FROM_ALL)
-add_custom_target(DUMMY ALL)
-add_dependencies(DUMMY boost-bootstrap)
 FIND_LIBRARY(LIBCLANG_PATH
     clang HINTS ${CMAKE_CXX_COMPILER}/../../
 )

--- a/pycode/memilio-generation/memilio/generation_test/test_oseir_generation.py
+++ b/pycode/memilio-generation/memilio/generation_test/test_oseir_generation.py
@@ -51,11 +51,6 @@ class TestOseirGeneration(unittest.TestCase):
         cmake_cmd, stdout=subprocess.PIPE, cwd=build_dir.name)
     cmake_cmd_result.check_returncode()
 
-    cmake_cmd = ["cmake", "--build", ".", "--target", "boost-bootstrap"]
-    cmake_cmd_result = subprocess.run(
-        cmake_cmd, stdout=subprocess.PIPE, cwd=build_dir.name)
-    cmake_cmd_result.check_returncode()
-
     @patch('memilio.generation.scanner.utility.try_get_compilation_database_path')
     def setUp(self, try_get_compilation_database_path_mock):
         try_get_compilation_database_path_mock.return_value = self.build_dir.name


### PR DESCRIPTION
# Changes and Information

Download boost libs from a URL instead of git repository, archive download is much faster. Removed the bootstrapping code. With this increased speed, a minimal boost version is not necessary and not worth the maintenance.

Results from CI: compile times (with ccache and boost URL download) are down to ~4 mins, before they were at 20+. Obviously depends on many ccache hits and misses there are.

Not using the URL from github (e.g. https://github.com/boostorg/boost/archive/refs/tags/boost-1.84.0.tar.gz) since those archives don't actually contain the source code. I think the archive generation is automated, but the boost repo requires more setup before it is complete (subrepos, bootstrapping).

## Merge Request - Guideline Checklist

Please check our [git workflow](https://github.com/SciCompMod/memilio/wiki/git-workflow). Use the **draft** feature if the Pull Request is not yet ready to review.

Closes #992

### Checks by code author

- [x] Every addressed issue is linked (use the "Closes #ISSUE" keyword below)
- [x] New code adheres to [coding guidelines](https://github.com/SciCompMod/memilio/wiki/Coding-guidelines)
- [x] No large data files have been added (files should in sum not exceed 100 KB, avoid PDFs, Word docs, etc.)
- [x] Tests are added for new functionality and a local test run was successful (with and without OpenMP)
- [x] Appropriate **documentation** for new functionality has been added (Doxygen in the code and Markdown files if necessary)
- [x] Proper attention to licenses, especially no new third-party software with conflicting license has been added
- [ ] (For ABM development) Checked [benchmark results](https://github.com/SciCompMod/memilio/wiki/Agent-Based-Model-Development) and ran and posted a local test above from before and after development to ensure performance is monitored.

### Checks by code reviewer(s)

- [x] Corresponding issue(s) is/are linked and addressed
- [x] Code is clean of development artifacts (no deactivated or commented code lines, no debugging printouts, etc.)
- [x] Appropriate **unit tests** have been added, CI passes, code coverage and performance is acceptable (did not decrease)
- [x] No large data files added in the whole history of commits(files should in sum not exceed 100 KB, avoid PDFs, Word docs, etc.)
- [x] On merge, add 2-5 lines with the changes (main added features, changed items, or corrected bugs) to the merge-commit-message. This can be taken from the **briefly-list-the-changes** above (best case) or the separate commit messages (worst case).
