### PR TITLE
1174 Use DIVI data to scale initial values for LCT model

### DIFF
--- a/cpp/models/lct_secir/parameters_io.h
+++ b/cpp/models/lct_secir/parameters_io.h
@@ -38,6 +38,8 @@
 #include "memilio/epidemiology/lct_populations.h"
 
 #include <string>
+#include <vector>
+#include <type_traits>
 namespace mio
 {
 namespace lsecir
@@ -49,7 +51,9 @@ namespace details
 /**
 * @brief Processes one entry of an RKI data set for the definition of an initial value vector for an LCT population.
 *   
-* Takes one entry of an RKI data vector and changes the value in populations accordingly.
+* Takes one entry of an RKI data vector and changes the value in populations accordingly. 
+* This function provides sub-functionality of the set_initial_values_from_confirmed_cases() function.
+*
 * @param[out] populations The populations for which the inital data should be computed and set.
 * @param[in] entry The entry of the RKI data set.
 * @param[in] offset The offset between the date of the entry and the date for which the 
@@ -308,7 +312,8 @@ void process_entry(Populations& populations, const EntryType& entry, int offset,
         }
     }
 
-    // Compute Dead.
+    // Compute Dead by shifting RKI data according to mean stay times.
+    // This is because the RKI reports deaths with the date of the positive test, not the date of death.
     if (offset == std::floor(-staytimes[(size_t)InfectionState::InfectedSymptoms] -
                              staytimes[(size_t)InfectionState::InfectedSevere] -
                              staytimes[(size_t)InfectionState::InfectedCritical])) {
@@ -338,7 +343,7 @@ void process_entry(Populations& populations, const EntryType& entry, int offset,
 * @brief Computes an initialization vector for an LCT population with case data from RKI recursively for each age group
 *    (or for one age group in the case without age resolution).
 *   
-* Please use the set_initial_data_from_confirmed_cases() function, which calls this function automatically!
+* Please use the set_initial_values_from_reported_data() function, which calls this function automatically!
 * This function calculates a segment referring to the defined age group of the initial value vector with 
 *   subcompartments using the rki_data and the parameters.
 * The values for the whole initial value vector stored in populations are calculated recursively.
@@ -360,11 +365,10 @@ void process_entry(Populations& populations, const EntryType& entry, int offset,
 * @returns Any io errors that happen during data processing.
 */
 template <class Populations, class EntryType, size_t Group = 0>
-IOResult<void> set_initial_data_from_confirmed_cases_impl(Populations& populations,
-                                                          const std::vector<EntryType>& rki_data,
-                                                          const Parameters& parameters, Date date,
-                                                          const std::vector<ScalarType>& total_population,
-                                                          const std::vector<ScalarType>& scale_confirmed_cases)
+IOResult<void> set_initial_values_from_confirmed_cases(Populations& populations, const std::vector<EntryType>& rki_data,
+                                                       const Parameters& parameters, Date date,
+                                                       const std::vector<ScalarType>& total_population,
+                                                       const std::vector<ScalarType>& scale_confirmed_cases)
 {
     static_assert((Group < Populations::num_groups) && (Group >= 0), "The template parameter Group should be valid.");
     using LctStateGroup      = type_at_index_t<Group, typename Populations::LctStatesGroups>;
@@ -441,7 +445,7 @@ IOResult<void> set_initial_data_from_confirmed_cases_impl(Populations& populatio
 
     // Check if all values for populations are valid.
     for (size_t i = first_index_group; i < LctStateGroup::Count; i++) {
-        if (floating_point_less((ScalarType)populations[i], 0., 1e-14)) {
+        if (floating_point_less<ScalarType>((ScalarType)populations[i], 0., Limits<ScalarType>::zero_tolerance())) {
             log_error("Something went wrong in the initialization of group {:d}. At least one entry is negative.",
                       Group);
             return failure(StatusCode::InvalidValue,
@@ -450,17 +454,176 @@ IOResult<void> set_initial_data_from_confirmed_cases_impl(Populations& populatio
     }
 
     if constexpr (Group + 1 < Populations::num_groups) {
-        return set_initial_data_from_confirmed_cases_impl<Populations, EntryType, Group + 1>(
+        return set_initial_values_from_confirmed_cases<Populations, EntryType, Group + 1>(
             populations, rki_data, parameters, date, total_population, scale_confirmed_cases);
     }
     else {
-        return mio::success();
+        return success();
+    }
+}
+
+/**
+* @brief Computes the total number of patients in Intensive Care Units (in all groups and subcompartments) 
+*       in the provided Population.
+*   
+* This function calculates the total number of individuals within the compartment InfectedCritical 
+* for the Populations-data provided, irrespective of their subcompartment or group. 
+* This total number can be used to scale the entries so that the total number in InfectedCritical is equal to 
+* the number of ICU patients reported in the DIVI data. 
+* Please use the set_initial_values_from_reported_data() function, which calls this function automatically!
+*
+* @param[in] populations The populations for which the total number in InfectedCritical should be computed.
+* @tparam Populations is expected to be an LctPopulations defined in epidemiology/lct_populations. 
+*   This defined the number of age groups and the number of subcompartments used.
+* @tparam Group The age group for which the total number should be calculated. The function is called recursively 
+*   such that the total number in InfectedCritical within all groups is calculated if Group is zero at the beginning.
+* @returns The total number of patients in Intensive Care Units (in all groups and subcompartments).
+*/
+template <class Populations, size_t Group = 0>
+ScalarType get_total_InfectedCritical_from_populations(const Populations& populations)
+{
+    using LctStateGroup      = type_at_index_t<Group, typename Populations::LctStatesGroups>;
+    size_t first_index_group = populations.template get_first_index_of_group<Group>();
+
+    ScalarType infectedCritical_Group =
+        populations.get_compartments()
+            .segment(first_index_group + LctStateGroup::template get_first_index<InfectionState::InfectedCritical>(),
+                     LctStateGroup::template get_num_subcompartments<InfectionState::InfectedCritical>())
+            .sum();
+
+    if constexpr (Group + 1 < Populations::num_groups) {
+        return infectedCritical_Group +
+               get_total_InfectedCritical_from_populations<Populations, Group + 1>(populations);
+    }
+    else {
+        return infectedCritical_Group;
+    }
+}
+
+/**
+* @brief Extract the reported number of patients in ICU for a specific date from DIVI data.
+*
+* @param[in] divi_data Vector with reported DIVI data.
+* @param[in] date Date for which the reported number of patients in ICU should be extracted.
+* @returns The reported number of patients in ICU or any io errors that happen during data processing.
+*/
+IOResult<ScalarType> get_icu_from_divi_data(const std::vector<DiviEntry>& divi_data, const Date date)
+{
+    for (auto&& entry : divi_data) {
+        int offset = get_offset_in_days(entry.date, date);
+        if (offset == 0) {
+            return success(entry.num_icu);
+        }
+    }
+    log_error("Specified date does not exist in DIVI data.");
+    return failure(StatusCode::OutOfRange, "Specified date does not exist in DIVI data.");
+}
+
+/**
+* @brief Rescales the entries for InfectedCritical in populations such that the total number 
+*   equals the reported number.
+*   
+* This function rescales the entries for InfectedCritical in the given population for every group and subcompartment 
+* such that the total number in all InfectedCritical compartments equals the reported number infectedCritical_reported.
+*
+* If the total of individuals in InfectedCritical in populations is zero and the reported number is not,
+* the reported number is distributed uniformly across the groups. 
+* Within the groups, the number is distributed equally to the subcompartments. 
+* Note that especially the uniform distribution across groups is not necessarily realistic, 
+* because the need for intensive care can differ by group.
+*
+* @param[in,out] populations The populations for which the entries of the InfectedCritical compartments are rescaled.
+* @param[in] infectedCritical_reported The reported number for patients in ICU. The total number of individuals in the 
+*   InfectedCritical compartment in populations will be equal to this value afterward.
+*   You can calculate this value with the get_icu_from_divi_data() function.
+* @param[in] infectedCritical_populations The current total number of individuals in the InfectedCritical compartment 
+*   in populations. You can calculate this value with the get_total_InfectedCritical_from_populations() function.
+* @tparam Populations is expected to be an LctPopulations defined in epidemiology/lct_populations. 
+*   This defined the number of age groups and the number of subcompartments used.
+* @tparam Group The age group for which the entries of InfectedCritical should be scaled. 
+*   The function is called recursively for the groups. The total number in the InfectedCritical compartments is only 
+*   equal to infectedCritical_reported after the function call if Group is set to zero in the beginning.
+* @returns Any io errors that happen during the scaling.
+*/
+template <class Populations, size_t Group = 0>
+IOResult<void> rescale_to_divi_data(Populations& populations, const ScalarType infectedCritical_reported,
+                                    const ScalarType infectedCritical_populations)
+{
+    if (floating_point_less<ScalarType>(infectedCritical_reported, 0., Limits<ScalarType>::zero_tolerance())) {
+        log_error("The provided reported number of InfectedCritical is negative. Please check the data.");
+        return failure(StatusCode::InvalidValue,
+                       "The provided reported number of InfectedCritical is negative. Please check the data.");
+    }
+
+    using LctStateGroup      = type_at_index_t<Group, typename Populations::LctStatesGroups>;
+    size_t first_index_group = populations.template get_first_index_of_group<Group>();
+
+    if (floating_point_equal<ScalarType>(infectedCritical_populations, 0., Limits<ScalarType>::zero_tolerance())) {
+        if (!(floating_point_equal<ScalarType>(infectedCritical_reported, 0., Limits<ScalarType>::zero_tolerance()))) {
+            log_info("The calculated number of patients in intensive care is zero, although the reported number is "
+                     "not. The reported number is uniformly distributed across groups and subcompartments. Note "
+                     "that this is not necessarily realistic.");
+            size_t num_InfectedCritical =
+                LctStateGroup::template get_num_subcompartments<InfectionState::InfectedCritical>();
+            ScalarType num_age_groups = (ScalarType)Populations::num_groups;
+            // Distribute reported number uniformly to age groups and subcompartments.
+            for (size_t subcompartment = 0;
+                 subcompartment < LctStateGroup::template get_num_subcompartments<InfectionState::InfectedCritical>();
+                 subcompartment++) {
+                populations[first_index_group +
+                            LctStateGroup::template get_first_index<InfectionState::InfectedCritical>() +
+                            subcompartment] =
+                    infectedCritical_reported / ((ScalarType)num_InfectedCritical * num_age_groups);
+            }
+            // Adjust Recovered compartment.
+            populations[first_index_group + LctStateGroup::template get_first_index<InfectionState::Recovered>()] -=
+                infectedCritical_reported / num_age_groups;
+            // Number of Susceptibles is not affected because Recovered is adjusted accordingly.
+        }
+    }
+    else {
+        // Adjust number of Recovered by adding the old number in InfectedCritical
+        // and subtracting the new number (= scaling_factor * old number).
+        ScalarType scaling_factor = infectedCritical_reported / infectedCritical_populations;
+        populations[first_index_group + LctStateGroup::template get_first_index<InfectionState::Recovered>()] +=
+            (1 - scaling_factor) *
+            populations.get_compartments()
+                .segment(first_index_group +
+                             LctStateGroup::template get_first_index<InfectionState::InfectedCritical>(),
+                         LctStateGroup::template get_num_subcompartments<InfectionState::InfectedCritical>())
+                .sum();
+        // Adjust InfectedCritical.
+        for (size_t subcompartment = 0;
+             subcompartment < LctStateGroup::template get_num_subcompartments<InfectionState::InfectedCritical>();
+             subcompartment++) {
+            populations[first_index_group +
+                        LctStateGroup::template get_first_index<InfectionState::InfectedCritical>() + subcompartment] *=
+                scaling_factor;
+        }
+        // Number of Susceptibles is not affected because Recovered is adjusted accordingly.
+    }
+    if (floating_point_less<ScalarType>(
+            (ScalarType)
+                populations[first_index_group + LctStateGroup::template get_first_index<InfectionState::Recovered>()],
+            0., Limits<ScalarType>::zero_tolerance())) {
+        log_error(
+            "Scaling with reported DIVI data led to a negative entry in the Recovered compartment for group {:d}.",
+            Group);
+        return failure(StatusCode::InvalidValue,
+                       "Scaling with reported DIVI data led to a negative entry in a Recovered compartment.");
+    }
+    if constexpr (Group + 1 < Populations::num_groups) {
+        return rescale_to_divi_data<Populations, Group + 1>(populations, infectedCritical_reported,
+                                                            infectedCritical_populations);
+    }
+    else {
+        return success();
     }
 }
 } // namespace details
 
 /**
-* @brief Computes an initialization vector for an LCT population with case data from RKI.
+* @brief Computes an initialization vector for an LCT population with case data from RKI (and DIVI data).
 *   
 * Use just one group in the definition of the populations to not divide between age groups.
 * Otherwise, the number of groups has to match the number of RKI age groups.
@@ -479,6 +642,11 @@ IOResult<void> set_initial_data_from_confirmed_cases_impl(Populations& populatio
 * The data and the number of entries in the total_population and scale_confirmed_cases vectors have to match the 
 *   number of groups used in Populations.
 *
+* Additionally, one can scale the result from the calculation with the RKI data to match the reported number of 
+* patients in ICUs. The patient numbers are provided by DIVI and can be downloaded e.g. using 
+* pycode/memilio-epidata/memilio/epidata/getDIVIData.py (One should also set impute_dates=True so that missing dates
+* are imputed.). Again, to read the data into a vector, use the functionality from epi_data.h.
+*
 * @param[in] rki_data Vector with the RKI data.
 * @param[out] populations The populations for which the inital data should be computed and set.
 * @param[in] parameters The parameters that should be used to calculate the initial values. 
@@ -487,6 +655,9 @@ IOResult<void> set_initial_data_from_confirmed_cases_impl(Populations& populatio
 * @param[in] total_population Total size of the population of Germany or of every age group. 
 * @param[in] scale_confirmed_cases Factor(s for each age group) by which to scale the confirmed cases of the rki data 
 *   to consider unreported cases.
+* @param[in] divi_data Vector with DIVI data used to scale the number of individuals in the InfectedCritical 
+*   compartments in populations so that the total number match the reported number. 
+*   For the default value (an empty vector), the calculated populations using the RKI data is not scaled.
 * @tparam Populations is expected to be an LctPopulations defined in epidemiology/lct_populations. 
 *   This defined the number of age groups and the number of subcompartments used.
 * @tparam EntryType is expected to be ConfirmedCasesNoAgeEntry for data that is not age resolved and 
@@ -494,10 +665,11 @@ IOResult<void> set_initial_data_from_confirmed_cases_impl(Populations& populatio
 * @returns Any io errors that happen during data processing.
 */
 template <class Populations, class EntryType>
-IOResult<void> set_initial_data_from_confirmed_cases(const std::vector<EntryType>& rki_data, Populations& populations,
+IOResult<void> set_initial_values_from_reported_data(const std::vector<EntryType>& rki_data, Populations& populations,
                                                      const Parameters& parameters, const Date date,
                                                      const std::vector<ScalarType>& total_population,
-                                                     const std::vector<ScalarType>& scale_confirmed_cases)
+                                                     const std::vector<ScalarType>& scale_confirmed_cases,
+                                                     const std::vector<DiviEntry>& divi_data = std::vector<DiviEntry>())
 { // Check if the inputs are matching.
     assert(total_population.size() == Populations::num_groups);
     assert(scale_confirmed_cases.size() == Populations::num_groups);
@@ -525,8 +697,26 @@ IOResult<void> set_initial_data_from_confirmed_cases(const std::vector<EntryType
     for (size_t i = 0; i < populations.get_num_compartments(); i++) {
         populations[i] = 0;
     }
-    return details::set_initial_data_from_confirmed_cases_impl<Populations, EntryType>(
+    // Set populations using the RKI data.
+    IOResult<void> ioresult_confirmedcases = details::set_initial_values_from_confirmed_cases<Populations, EntryType>(
         populations, rki_data, parameters, date, total_population, scale_confirmed_cases);
+    if (!(ioresult_confirmedcases)) {
+        return ioresult_confirmedcases;
+    }
+
+    // Check if DIVI data is provided and scale the result in populations accordingly.
+    if (!divi_data.empty()) {
+        ScalarType infectedCritical_populations =
+            details::get_total_InfectedCritical_from_populations<Populations>(populations);
+        auto infectedCritical_reported = details::get_icu_from_divi_data(divi_data, date);
+        if (!(infectedCritical_reported)) {
+            return infectedCritical_reported.error();
+        }
+        return details::rescale_to_divi_data<Populations>(populations, infectedCritical_reported.value(),
+                                                          infectedCritical_populations);
+    }
+
+    return success();
 }
 
 } // namespace lsecir

--- a/cpp/models/lct_secir/parameters_io.h
+++ b/cpp/models/lct_secir/parameters_io.h
@@ -366,7 +366,7 @@ void process_entry(Populations& populations, const EntryType& entry, int offset,
 */
 template <class Populations, class EntryType, size_t Group = 0>
 IOResult<void> set_initial_values_from_confirmed_cases(Populations& populations, const std::vector<EntryType>& rki_data,
-                                                       const Parameters& parameters, Date date,
+                                                       const Parameters& parameters, const Date date,
                                                        const std::vector<ScalarType>& total_population,
                                                        const std::vector<ScalarType>& scale_confirmed_cases)
 {
@@ -526,9 +526,9 @@ IOResult<ScalarType> get_icu_from_divi_data(const std::vector<DiviEntry>& divi_d
 * This function rescales the entries for InfectedCritical in the given population for every group and subcompartment 
 * such that the total number in all InfectedCritical compartments equals the reported number infectedCritical_reported.
 *
-* If the total of individuals in InfectedCritical in populations is zero and the reported number is not,
+* If the total number of individuals in InfectedCritical in populations is zero and the reported number is not,
 * the reported number is distributed uniformly across the groups. 
-* Within the groups, the number is distributed equally to the subcompartments. 
+* Within the groups, the number is distributed uniformly to the subcompartments. 
 * Note that especially the uniform distribution across groups is not necessarily realistic, 
 * because the need for intensive care can differ by group.
 *
@@ -539,7 +539,7 @@ IOResult<ScalarType> get_icu_from_divi_data(const std::vector<DiviEntry>& divi_d
 * @param[in] infectedCritical_populations The current total number of individuals in the InfectedCritical compartment 
 *   in populations. You can calculate this value with the get_total_InfectedCritical_from_populations() function.
 * @tparam Populations is expected to be an LctPopulations defined in epidemiology/lct_populations. 
-*   This defined the number of age groups and the number of subcompartments used.
+*   This defines the number of age groups and the number of subcompartments.
 * @tparam Group The age group for which the entries of InfectedCritical should be scaled. 
 *   The function is called recursively for the groups. The total number in the InfectedCritical compartments is only 
 *   equal to infectedCritical_reported after the function call if Group is set to zero in the beginning.
@@ -623,7 +623,7 @@ IOResult<void> rescale_to_divi_data(Populations& populations, const ScalarType i
 } // namespace details
 
 /**
-* @brief Computes an initialization vector for an LCT population with case data from RKI (and DIVI data).
+* @brief Computes an initialization vector for an LCT population with case data from RKI (and possibly DIVI data).
 *   
 * Use just one group in the definition of the populations to not divide between age groups.
 * Otherwise, the number of groups has to match the number of RKI age groups.
@@ -659,7 +659,7 @@ IOResult<void> rescale_to_divi_data(Populations& populations, const ScalarType i
 *   compartments in populations so that the total number match the reported number. 
 *   For the default value (an empty vector), the calculated populations using the RKI data is not scaled.
 * @tparam Populations is expected to be an LctPopulations defined in epidemiology/lct_populations. 
-*   This defined the number of age groups and the number of subcompartments used.
+*   This defines the number of age groups and the number of subcompartments.
 * @tparam EntryType is expected to be ConfirmedCasesNoAgeEntry for data that is not age resolved and 
 *   ConfirmedCasesDataEntry for age resolved data. See also epi_data.h.
 * @returns Any io errors that happen during data processing.

--- a/cpp/models/lct_secir/parameters_io.h
+++ b/cpp/models/lct_secir/parameters_io.h
@@ -68,7 +68,7 @@ namespace details
 *    for which the initial value vector is calculated.
 * @param[in] scale_confirmed_cases Factor by which to scale the confirmed cases of RKI data to consider unreported cases.
 * @tparam Populations is expected to be an LctPopulations defined in epidemiology/lct_populations. 
-*   This defined the number of age groups and the number of subcompartments used.
+*   This defines the number of age groups and the numbers of subcompartments.
 * @tparam EntryType The type of the data entry of the RKI data.
 * @tparam Group The age group of the entry the should be processed.
 */
@@ -357,7 +357,7 @@ void process_entry(Populations& populations, const EntryType& entry, int offset,
 * @param[in] scale_confirmed_cases Factor(s for each age group) by which to scale the confirmed cases of the rki data 
 *   to consider unreported cases.
 * @tparam Populations is expected to be an LctPopulations defined in epidemiology/lct_populations. 
-*   This defined the number of age groups and the number of subcompartments used.
+*   This defines the number of age groups and the numbers of subcompartments.
 * @tparam EntryType is expected to be ConfirmedCasesNoAgeEntry for data that is not age resolved and 
 *   ConfirmedCasesDataEntry for age resolved data. See also epi_data.h.
 * @tparam Group The age group for which the initial values should be calculated. The function is called recursively 
@@ -474,7 +474,7 @@ IOResult<void> set_initial_values_from_confirmed_cases(Populations& populations,
 *
 * @param[in] populations The populations for which the total number in InfectedCritical should be computed.
 * @tparam Populations is expected to be an LctPopulations defined in epidemiology/lct_populations. 
-*   This defined the number of age groups and the number of subcompartments used.
+*   This defines the number of age groups and the numbers of subcompartments.
 * @tparam Group The age group for which the total number should be calculated. The function is called recursively 
 *   such that the total number in InfectedCritical within all groups is calculated if Group is zero at the beginning.
 * @returns The total number of patients in Intensive Care Units (in all groups and subcompartments).
@@ -539,7 +539,7 @@ IOResult<ScalarType> get_icu_from_divi_data(const std::vector<DiviEntry>& divi_d
 * @param[in] infectedCritical_populations The current total number of individuals in the InfectedCritical compartment 
 *   in populations. You can calculate this value with the get_total_InfectedCritical_from_populations() function.
 * @tparam Populations is expected to be an LctPopulations defined in epidemiology/lct_populations. 
-*   This defines the number of age groups and the number of subcompartments.
+*   This defines the number of age groups and the numbers of subcompartments.
 * @tparam Group The age group for which the entries of InfectedCritical should be scaled. 
 *   The function is called recursively for the groups. The total number in the InfectedCritical compartments is only 
 *   equal to infectedCritical_reported after the function call if Group is set to zero in the beginning.
@@ -584,9 +584,9 @@ IOResult<void> rescale_to_divi_data(Populations& populations, const ScalarType i
     else {
         // Adjust number of Recovered by adding the old number in InfectedCritical
         // and subtracting the new number (= scaling_factor * old number).
-        ScalarType scaling_factor = infectedCritical_reported / infectedCritical_populations;
+        ScalarType scaling_factor_infectedCritical = infectedCritical_reported / infectedCritical_populations;
         populations[first_index_group + LctStateGroup::template get_first_index<InfectionState::Recovered>()] +=
-            (1 - scaling_factor) *
+            (1 - scaling_factor_infectedCritical) *
             populations.get_compartments()
                 .segment(first_index_group +
                              LctStateGroup::template get_first_index<InfectionState::InfectedCritical>(),
@@ -598,7 +598,7 @@ IOResult<void> rescale_to_divi_data(Populations& populations, const ScalarType i
              subcompartment++) {
             populations[first_index_group +
                         LctStateGroup::template get_first_index<InfectionState::InfectedCritical>() + subcompartment] *=
-                scaling_factor;
+                scaling_factor_infectedCritical;
         }
         // Number of Susceptibles is not affected because Recovered is adjusted accordingly.
     }
@@ -659,7 +659,7 @@ IOResult<void> rescale_to_divi_data(Populations& populations, const ScalarType i
 *   compartments in populations so that the total number match the reported number. 
 *   For the default value (an empty vector), the calculated populations using the RKI data is not scaled.
 * @tparam Populations is expected to be an LctPopulations defined in epidemiology/lct_populations. 
-*   This defines the number of age groups and the number of subcompartments.
+*   This defines the number of age groups and the numbers of subcompartments.
 * @tparam EntryType is expected to be ConfirmedCasesNoAgeEntry for data that is not age resolved and 
 *   ConfirmedCasesDataEntry for age resolved data. See also epi_data.h.
 * @returns Any io errors that happen during data processing.


### PR DESCRIPTION
# Changes and Information

Please **briefly list the changes** (main added features, changed items, or corrected bugs) made:

- Method to calculate an initial value vector for an LCT model using reported RKI data now provides the option to scale the result so that the number of ICU patients equals the reported number in the DIVI data set.
- Added tests.


If need be, add additional information and what the reviewer should look out for in particular:

- %
-

## Merge Request - Guideline Checklist

Please check our [git workflow](https://github.com/SciCompMod/memilio/wiki/git-workflow). Use the **draft** feature if the Pull Request is not yet ready to review.

### Checks by code author

- [x] Every addressed issue is linked (use the "Closes #ISSUE" keyword below)
- [x] New code adheres to [coding guidelines](https://github.com/SciCompMod/memilio/wiki/Coding-guidelines)
- [x] No large data files have been added (files should in sum not exceed 100 KB, avoid PDFs, Word docs, etc.)
- [x] Tests are added for new functionality and a local test run was successful (with and without OpenMP)
- [x] Appropriate **documentation** for new functionality has been added (Doxygen in the code and Markdown files if necessary)
- [x] Proper attention to licenses, especially no new third-party software with conflicting license has been added
- [ ] (For ABM development) Checked [benchmark results](https://github.com/SciCompMod/memilio/wiki/Agent-Based-Model-Development) and ran and posted a local test above from before and after development to ensure performance is monitored.

### Checks by code reviewer(s)

- [x] Corresponding issue(s) is/are linked and addressed
- [x] Code is clean of development artifacts (no deactivated or commented code lines, no debugging printouts, etc.)
- [x] Appropriate **unit tests** have been added, CI passes, code coverage and performance is acceptable (did not decrease)
- [x] No large data files added in the whole history of commits(files should in sum not exceed 100 KB, avoid PDFs, Word docs, etc.)
- [ ] On merge, add 2-5 lines with the changes (main added features, changed items, or corrected bugs) to the merge-commit-message. This can be taken from the **briefly-list-the-changes** above (best case) or the separate commit messages (worst case).

Closes #1174 .