### PR TITLE
1324 Direclty print output from print_table in python

### DIFF
--- a/pycode/examples/simulation/ode_seir_flows.py
+++ b/pycode/examples/simulation/ode_seir_flows.py
@@ -70,8 +70,8 @@ def run_ode_seir_flows_simulation():
     # Run flow simulation
     (result, flows) = simulate_flows(0, days, dt, model)
 
-    print(result.print_table(["S", "E", "I", "R"], 16, 5))
-    print(flows.print_table(["S->E", "E->I", "I->R"], 16, 5))
+    result.print_table(["S", "E", "I", "R"], 16, 5)
+    flows.print_table(["S->E", "E->I", "I->R"], 16, 5)
 
 
 if __name__ == "__main__":

--- a/pycode/memilio-simulation/memilio/simulation/bindings/utils/time_series.cpp
+++ b/pycode/memilio-simulation/memilio/simulation/bindings/utils/time_series.cpp
@@ -67,13 +67,20 @@ void bind_time_series(py::module_& m, std::string const& name)
             "print_table",
             [](const mio::TimeSeries<double>& self, const std::vector<std::string>& column_labels, size_t width,
                size_t precision, char separator, const std::string& header_prefix) {
+                self.print_table(column_labels, width, precision, separator, header_prefix);
+            },
+            py::arg("column_labels") = std::vector<std::string>{}, py::arg("width") = 16, py::arg("precision") = 5,
+            py::arg("separator") = ' ', py::arg("header_prefix") = "\n")
+        .def(
+            "print_table",
+            [](const mio::TimeSeries<double>& self, bool return_string, const std::vector<std::string>& column_labels,
+               size_t width, size_t precision, char separator, const std::string& header_prefix) {
                 std::ostringstream oss;
                 self.print_table(oss, column_labels, width, precision, separator, header_prefix);
                 return oss.str();
             },
-            py::arg("column_labels") = std::vector<std::string>{}, py::arg("width") = 16, py::arg("precision") = 5,
-            py::arg("separator") = ' ', py::arg("header_prefix") = "\n")
-
+            py::arg("return_string"), py::arg("column_labels") = std::vector<std::string>{}, py::arg("width") = 16,
+            py::arg("precision") = 5, py::arg("separator") = ' ', py::arg("header_prefix") = "\n")
         .def(
             "export_csv",
             [](const mio::TimeSeries<double>& self, const std::string& filename,

--- a/pycode/memilio-simulation/memilio/simulation_test/test_time_series.py
+++ b/pycode/memilio-simulation/memilio/simulation_test/test_time_series.py
@@ -65,7 +65,7 @@ class Test_TimeSeries(unittest.TestCase):
         ts = mio.TimeSeries(1)
         ts.add_time_point(2, np.r_[1])
         ts.add_time_point(3.5, np.r_[2])
-        output = ts.print_table(["a", "b"], 2, 2)
+        output = ts.print_table(True, ["a", "b"], 2, 2)
         self.assertEqual(
             output, '\nTime a \n2.00 1.00\n3.50 2.00\n')
 
@@ -74,9 +74,24 @@ class Test_TimeSeries(unittest.TestCase):
         ts = mio.TimeSeries(1)
         ts.add_time_point(2, np.r_[1])
         ts.add_time_point(3.5, np.r_[2])
-        output = ts.print_table(["a"], 4, 1, ',', "# ")
+        output = ts.print_table(True, ["a"], 4, 1, ',', "# ")
         self.assertEqual(
             output, '# Time,a   \n 2.0, 1.0\n 3.5, 2.0\n')
+
+    def test_print_table_console_output(self):
+        """Test the new print_table function that prints directly to console"""
+        ts = mio.TimeSeries(1)
+        ts.add_time_point(2, np.r_[1])
+        ts.add_time_point(3.5, np.r_[2])
+
+        # Test that print_table() without return_string parameter returns None
+        # (meaning it prints directly to console)
+        result = ts.print_table()
+        self.assertIsNone(result)
+
+        # Test that print_table() with custom parameters still prints to console
+        result = ts.print_table(["Column1"], 10, 2)
+        self.assertIsNone(result)
 
     def test_export_csv(self):
         """Test export_csv functionality"""


### PR DESCRIPTION
# Changes and Information

Please **briefly list the changes** (main added features, changed items, or corrected bugs) made:

- When calling print_table from python, the output is now direclty printed in the console per default.
- When adding True as first arg, we also can still return the output as a string.


If need be, add additional information and what the reviewer should look out for in particular:

-
-

## Merge Request - Guideline Checklist

Please check our [git workflow](https://memilio.readthedocs.io/en/latest/development.html#git-workflow). Use the **draft** feature if the Pull Request is not yet ready to review.

### Checks by code author

- [ ] Every addressed issue is linked (use the "Closes #ISSUE" keyword below)
- [ ] New code adheres to [coding guidelines](https://memilio.readthedocs.io/en/latest/development.html#coding-guidelines)
- [ ] No large data files have been added (files should in sum not exceed 100 KB, avoid PDFs, Word docs, etc.)
- [ ] Tests are added for new functionality and a local test run was successful (with and without OpenMP)
- [ ] Appropriate **documentation** for new functionality has been added (Doxygen in the code and explanations in the online documentation)
- [ ] Proper attention to licenses, especially no new third-party software with conflicting license has been added
- [ ] (For ABM development) Checked [benchmark results](https://memilio.readthedocs.io/en/latest/development.html#agent-based-model-development) and ran and posted a local test above from before and after development to ensure performance is monitored.

### Checks by code reviewer(s)

- [ ] Corresponding issue(s) is/are linked and addressed
- [ ] Code is clean of development artifacts (no deactivated or commented code lines, no debugging printouts, etc.)
- [ ] Appropriate **unit tests** have been added, CI passes, code coverage and performance is acceptable (did not decrease)
- [ ] No large data files added in the whole history of commits(files should in sum not exceed 100 KB, avoid PDFs, Word docs, etc.)
- [ ] On merge, add 2-5 lines with the changes (main added features, changed items, or corrected bugs) to the merge-commit-message. This can be taken from the **briefly-list-the-changes** above (best case) or the separate commit messages (worst case).
