### PR TITLE
1463 Remove log outputs from testing

### DIFF
--- a/cpp/memilio/utils/parameter_distributions.h
+++ b/cpp/memilio/utils/parameter_distributions.h
@@ -20,7 +20,6 @@
 #ifndef PARAMETER_DISTRIBUTIONS_H
 #define PARAMETER_DISTRIBUTIONS_H
 
-#include "memilio/utils/compiler_diagnostics.h"
 #include "memilio/utils/logging.h"
 #include "memilio/utils/visitor.h"
 #include "memilio/utils/random_number_generator.h"
@@ -275,11 +274,6 @@ public:
         return m_standard_dev;
     }
 
-    void log_stddev_changes(bool log_stddev_change)
-    {
-        m_log_stddev_change = log_stddev_change;
-    }
-
     void set_lower_bound(ScalarType lower_bound)
     {
         m_lower_bound = lower_bound;
@@ -338,7 +332,7 @@ public:
 
         int i            = 0;
         int retries      = 10;
-        ScalarType rnumb = m_distribution.get_distribution_instance()(thread_local_rng(), m_distribution.params);
+        ScalarType rnumb = m_distribution.get_distribution_instance()(rng, m_distribution.params);
         while ((rnumb > m_upper_bound || rnumb < m_lower_bound) && i < retries) {
             rnumb = m_distribution.get_distribution_instance()(rng, m_distribution.params);
             i++;
@@ -430,7 +424,6 @@ private:
     ScalarType m_lower_bound = std::numeric_limits<ScalarType>::min();
     ScalarType m_quantile    = 2.5758; // default is 0.995 quartile
     NormalDistribution<ScalarType>::ParamType m_distribution;
-    bool m_log_stddev_change = true;
 };
 
 template <class IOObj>

--- a/cpp/tests/random_number_test.h
+++ b/cpp/tests/random_number_test.h
@@ -59,9 +59,9 @@ public:
 protected:
     void SetUp() override
     {
-        log_rng_seeds(m_rng, mio::LogLevel::warn);
+        m_rng.set_counter(mio::Counter<uint64_t>{0});
     }
 
 private:
-    mio::RandomNumberGenerator m_rng{}; ///< Seeded rng used by this test fixture.
+    static inline mio::RandomNumberGenerator m_rng = mio::thread_local_rng(); ///< Seeded rng used by this test fixture.
 };

--- a/cpp/tests/test_abstract_parameter_dist.cpp
+++ b/cpp/tests/test_abstract_parameter_dist.cpp
@@ -23,13 +23,10 @@
 #include "memilio/utils/random_number_generator.h"
 #include "models/abm/personal_rng.h"
 #include <gtest/gtest.h>
-#include <stdio.h>
 #include <vector>
 
 TEST(AbstractParameterDist, test_abstract_normal_distribution)
 {
-    mio::log_thread_local_rng_seeds(mio::LogLevel::warn);
-
     mio::AbstractParameterDistribution p1(mio::ParameterDistributionNormal(10., 0.5));
     mio::AbstractParameterDistribution p2(mio::ParameterDistributionNormal(20., 0.3));
     auto params1 = std::vector<double>{10., 0.5};
@@ -52,8 +49,6 @@ TEST(AbstractParameterDist, test_abstract_normal_distribution)
 
 TEST(AbstractParameterDist, test_abstract_uniform_distribution)
 {
-    mio::log_thread_local_rng_seeds(mio::LogLevel::warn);
-
     mio::AbstractParameterDistribution p1(mio::ParameterDistributionUniform(0., 1.));
     mio::AbstractParameterDistribution p2(mio::ParameterDistributionUniform(2., 3.));
     auto params1 = std::vector<double>{0., 1.};
@@ -78,8 +73,6 @@ TEST(AbstractParameterDist, test_abstract_uniform_distribution)
 
 TEST(AbstractParameterDist, test_abstract_lognormal_distribution)
 {
-    mio::log_thread_local_rng_seeds(mio::LogLevel::warn);
-
     mio::AbstractParameterDistribution p1(mio::ParameterDistributionLogNormal(1., 0.25));
     mio::AbstractParameterDistribution p2(mio::ParameterDistributionLogNormal(2., 0.1));
     auto params1 = std::vector<double>{1., 0.25};
@@ -102,8 +95,6 @@ TEST(AbstractParameterDist, test_abstract_lognormal_distribution)
 
 TEST(AbstractParameterDist, test_abstract_exponential_distribution)
 {
-    mio::log_thread_local_rng_seeds(mio::LogLevel::warn);
-
     mio::AbstractParameterDistribution p1(mio::ParameterDistributionExponential(1.));
     mio::AbstractParameterDistribution p2(mio::ParameterDistributionExponential(2.));
     auto params1 = std::vector<double>{1.};
@@ -126,8 +117,6 @@ TEST(AbstractParameterDist, test_abstract_exponential_distribution)
 
 TEST(AbstractParameterDist, test_abstract_constant_distribution)
 {
-    mio::log_thread_local_rng_seeds(mio::LogLevel::warn);
-
     mio::AbstractParameterDistribution p1(mio::ParameterDistributionConstant(1.));
     mio::AbstractParameterDistribution p2(mio::ParameterDistributionConstant(2.));
     auto params1 = std::vector<double>{1.};

--- a/cpp/tests/test_binary_serializer.cpp
+++ b/cpp/tests/test_binary_serializer.cpp
@@ -17,22 +17,17 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-#include "boost/none.hpp"
-#include "boost/none_t.hpp"
 #include "matchers.h"
-#include "memilio/epidemiology/damping.h"
-#include "memilio/epidemiology/damping_sampling.h"
 #include "memilio/io/binary_serializer.h"
 #include "memilio/io/io.h"
 #include "memilio/utils/logging.h"
-#include "memilio/utils/parameter_distributions.h"
 #include "memilio/utils/time_series.h"
-#include "memilio/utils/uncertain_value.h"
 #include "ode_secir/model.h"
 #include "ode_secir/parameter_space.h"
-#include "ode_secir/parameters.h"
+#include "utils.h"
+
+#include "boost/none.hpp"
 #include "gtest/gtest.h"
-#include <memory>
 
 namespace
 {
@@ -180,10 +175,9 @@ TEST(BinarySerializer, model)
     //this test is only to make sure the correct number of bytes are serialized/deserialized
     //in a very complex object. correct serializing of single values is tested by other tests.
     mio::osecir::Model<double> model{5};
-    mio::set_log_level(mio::LogLevel::err);
     mio::osecir::set_params_distributions_normal<double>(model, 0, 10, 0.01);
-    mio::set_log_level(mio::LogLevel::warn);
     auto stream = mio::serialize_binary(model);
+    mio::LogLevelOverride llo(mio::LogLevel::off); // suppress warnings from model constructor
     auto result = mio::deserialize_binary(stream, mio::Tag<mio::osecir::Model<double>>{});
     EXPECT_THAT(result, IsSuccess());
 }

--- a/cpp/tests/test_epi_data_io.cpp
+++ b/cpp/tests/test_epi_data_io.cpp
@@ -17,14 +17,11 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-
-#include "abm/infection_state.h"
 #include "memilio/epidemiology/age_group.h"
 #include "memilio/geography/regions.h"
 #include "memilio/io/epi_data.h"
 #include "matchers.h"
 #include "memilio/io/io.h"
-#include "memilio/io/mobility_io.h"
 #include "test_data_dir.h"
 #include "gtest/gtest.h"
 #include "json/value.h"
@@ -32,6 +29,7 @@
 #include "ode_secirts/parameters_io.h"
 #include "memilio/utils/stl_util.h"
 #include "boost/optional/optional_io.hpp"
+#include "utils.h"
 #include <gmock/gmock-matchers.h>
 
 TEST(TestEpiDataIo, read_rki)
@@ -423,9 +421,12 @@ TEST(TestEpiData, set_vaccination_data)
     model.parameters.set<mio::osecirts::DaysUntilEffectiveBoosterImmunity<double>>(1);
     std::vector<mio::osecirts::Model<double>> model_vector{model};
 
-    auto f = mio::osecirts::details::set_vaccination_data(model_vector,
-                                                          mio::path_join(TEST_DATA_DIR, "vaccination_test.json"),
-                                                          mio::Date(2022, 4, 15), county_ids, num_days);
+    {
+        mio::LogLevelOverride llo(mio::LogLevel::off); // suppress "Vaccination data only available from [...]"
+        mio::unused(mio::osecirts::details::set_vaccination_data(model_vector,
+                                                                 mio::path_join(TEST_DATA_DIR, "vaccination_test.json"),
+                                                                 mio::Date(2022, 4, 15), county_ids, num_days));
+    }
 
     auto expected_values_PI =
         (Eigen::ArrayXd(num_age_groups * (num_days + 1)) << 7, 10, 20, 15, 10, 5, 2, 15, 8, 0).finished();

--- a/cpp/tests/test_graph.cpp
+++ b/cpp/tests/test_graph.cpp
@@ -37,6 +37,7 @@
 #include "memilio/utils/stl_util.h"
 #include "utils.h"
 #include "gmock/gmock-matchers.h"
+#include "gmock/gmock.h"
 #include <cstddef>
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
@@ -378,7 +379,7 @@ TEST(TestGraphBuilder, Build_unique)
     mio::RedirectLogger logger;
     logger.capture();
     auto g = std::move(builder).build(true);
-    EXPECT_THAT(logger.read(), testing::EndsWith("[warning] Removed duplicate edge(s)\n"));
+    EXPECT_THAT(logger.read(), testing::HasSubstr("[warning] Removed duplicate edge(s)"));
     logger.release();
 
     EXPECT_EQ(g.nodes().size(), 3);

--- a/cpp/tests/test_graph.cpp
+++ b/cpp/tests/test_graph.cpp
@@ -35,10 +35,12 @@
 #include "matchers.h"
 #include "temp_file_register.h"
 #include "memilio/utils/stl_util.h"
+#include "utils.h"
 #include "gmock/gmock-matchers.h"
 #include <cstddef>
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
+#include <sys/types.h>
 #include <type_traits>
 #include <string>
 
@@ -148,7 +150,7 @@ TEST(TestGraph, graph_without_edges)
     std::vector<int> ids          = {1, 2};
 
     mio::Graph<MockModel, MockMobility> g(ids, models);
-    
+
     EXPECT_EQ(g.edges().size(), 0);
     EXPECT_EQ(g.nodes().size(), 2);
     EXPECT_EQ(g.nodes()[0].id, 1);
@@ -373,7 +375,11 @@ TEST(TestGraphBuilder, Build_unique)
     builder.add_edge(1, 2, 200);
     builder.add_edge(2, 1, 300);
 
+    mio::RedirectLogger logger;
+    logger.capture();
     auto g = std::move(builder).build(true);
+    EXPECT_THAT(logger.read(), testing::EndsWith("[warning] Removed duplicate edge(s)\n"));
+    logger.release();
 
     EXPECT_EQ(g.nodes().size(), 3);
     EXPECT_EQ(g.edges().size(), 3);

--- a/cpp/tests/test_graph_abm.cpp
+++ b/cpp/tests/test_graph_abm.cpp
@@ -29,13 +29,10 @@
 #include "graph_abm/graph_abm_mobility.h"
 #include "memilio/epidemiology/age_group.h"
 #include "memilio/utils/logging.h"
-#include "memilio/utils/miompi.h"
 #include "memilio/mobility/graph.h"
-#include "abm_helpers.h"
-#include <algorithm>
-#include <cstddef>
+#include "utils.h"
+
 #include <gtest/gtest.h>
-#include <iostream>
 
 struct MockHistory {
 
@@ -253,10 +250,15 @@ TEST(TestGraphABM, test_get_person)
     auto& p1 = model.get_person(pid1);
     EXPECT_EQ(p1.get_location(), home);
     EXPECT_EQ(p1.get_age(), mio::AgeGroup(0));
-    model.remove_person(model.get_person_index(pid1));
-    EXPECT_EQ(model.get_person_index(pid1), std::numeric_limits<uint32_t>::max());
 
-    auto& p2 = model.get_person(pid2);
-    EXPECT_EQ(p2.get_location(), work);
-    EXPECT_EQ(p2.get_age(), mio::AgeGroup(1));
+    {
+        model.remove_person(model.get_person_index(pid1));
+
+        mio::LogLevelOverride llo(mio::LogLevel::off);
+        EXPECT_EQ(model.get_person_index(pid1), std::numeric_limits<uint32_t>::max());
+
+        auto& p2 = model.get_person(pid2);
+        EXPECT_EQ(p2.get_location(), work);
+        EXPECT_EQ(p2.get_age(), mio::AgeGroup(1));
+    }
 }

--- a/cpp/tests/test_odemseirs4.cpp
+++ b/cpp/tests/test_odemseirs4.cpp
@@ -23,6 +23,7 @@
 #include "ode_mseirs4/model.h"
 #include "ode_mseirs4/infection_state.h"
 #include "ode_mseirs4/parameters.h"
+#include "utils.h"
 
 #include <gtest/gtest.h>
 
@@ -113,6 +114,7 @@ TEST_F(ModelTestOdeMseirs4, checkPopulationConservation)
 
 TEST(TestOdeMseirs4, apply_constraints_parameters)
 {
+    mio::LogLevelOverride llo(mio::LogLevel::off); // hide contstraint warnings/errors
     mio::omseirs4::Model<double> model;
 
     auto& params = model.parameters;
@@ -148,6 +150,7 @@ TEST(TestOdeMseirs4, apply_constraints_parameters)
 
 TEST(TestOdeMseirs4, check_constraints_parameters)
 {
+    mio::LogLevelOverride llo(mio::LogLevel::off); // hide contstraint warnings/errors
     mio::omseirs4::Model<double> model;
     auto& params = model.parameters;
 

--- a/cpp/tests/test_odemseirs4.cpp
+++ b/cpp/tests/test_odemseirs4.cpp
@@ -114,7 +114,7 @@ TEST_F(ModelTestOdeMseirs4, checkPopulationConservation)
 
 TEST(TestOdeMseirs4, apply_constraints_parameters)
 {
-    mio::LogLevelOverride llo(mio::LogLevel::off); // hide contstraint warnings/errors
+    mio::LogLevelOverride llo(mio::LogLevel::off); // hide constraint warnings/errors
     mio::omseirs4::Model<double> model;
 
     auto& params = model.parameters;
@@ -150,7 +150,7 @@ TEST(TestOdeMseirs4, apply_constraints_parameters)
 
 TEST(TestOdeMseirs4, check_constraints_parameters)
 {
-    mio::LogLevelOverride llo(mio::LogLevel::off); // hide contstraint warnings/errors
+    mio::LogLevelOverride llo(mio::LogLevel::off); // hide constraint warnings/errors
     mio::omseirs4::Model<double> model;
     auto& params = model.parameters;
 

--- a/cpp/tests/test_odesecir.cpp
+++ b/cpp/tests/test_odesecir.cpp
@@ -1457,6 +1457,8 @@ TEST(TestOdeSecir, set_divi_data_invalid_dates)
 
 TEST(TestOdeSecir, set_divi_data_empty_data)
 {
+    mio::LogLevelOverride llo(mio::LogLevel::off);
+
     // Create an empty DIVI data vector
     std::vector<mio::DiviEntry> empty_data;
     std::vector<int> regions = {0, 1};
@@ -1473,6 +1475,7 @@ TEST(TestOdeSecir, set_divi_data_empty_data)
 
 TEST_F(ModelTestOdeSecir, set_confirmed_cases_data_with_ICU)
 {
+    mio::LogLevelOverride llo(mio::LogLevel::off);
     // set params
     for (auto age_group = mio::AgeGroup(0); age_group < (mio::AgeGroup)num_age_groups; age_group++) {
         model.parameters.get<mio::osecir::CriticalPerSevere<double>>()[age_group]         = 1.0;

--- a/cpp/tests/test_odesecir_ageres.cpp
+++ b/cpp/tests/test_odesecir_ageres.cpp
@@ -32,7 +32,7 @@ TEST(TestOdeSecir, compareAgeResWithPreviousRun)
     */
     double t0   = 0;
     double tmax = 50;
-    double dt   = 0.1;
+    double dt   = 0.3;
 
     double cont_freq = 10;
 
@@ -111,7 +111,7 @@ TEST(TestOdeSecir, compareAgeResWithPreviousRunCashKarp)
 {
     double t0   = 0;
     double tmax = 50;
-    double dt   = 0.1;
+    double dt   = 0.3;
 
     double cont_freq = 10;
 

--- a/cpp/tests/test_odesecirts.cpp
+++ b/cpp/tests/test_odesecirts.cpp
@@ -19,6 +19,7 @@
 */
 
 #include "matchers.h"
+#include "memilio/utils/logging.h"
 #include "temp_file_register.h"
 #include "test_data_dir.h"
 #include "memilio/data/analyze_result.h"
@@ -42,6 +43,7 @@
 #include "ode_secirts/parameters.h"
 #include "ode_secirts/parameters_io.h"
 #include "ode_secirts/analyze_result.h"
+#include "utils.h"
 
 #include "gtest/gtest.h"
 #include "gmock/gmock-matchers.h"
@@ -594,6 +596,7 @@ mio::osecirts::Model<double> make_model(int num_age_groups, bool set_invalid_ini
     set_synthetic_population_data(model.populations, set_invalid_initial_value);
     set_demographic_parameters(model.parameters, set_invalid_initial_value);
     set_contact_parameters(model.parameters, set_invalid_initial_value);
+    mio::LogLevelOverride llo(mio::LogLevel::off);
     model.parameters.apply_constraints();
     return model;
 }
@@ -1037,12 +1040,13 @@ TEST(TestOdeSECIRTS, model_initialization)
     const std::vector<std::vector<double>> immunity_population = {{0.04, 0.04, 0.075, 0.08, 0.035, 0.01},
                                                                   {0.61, 0.61, 0.62, 0.62, 0.58, 0.41},
                                                                   {0.35, 0.35, 0.305, 0.3, 0.385, 0.58}};
-
-    ASSERT_THAT(mio::osecirts::read_input_data_county(model_vector, {2020, 12, 01}, {0},
-                                                      std::vector<double>(size_t(num_age_groups), 1.0), 1.0,
-                                                      TEST_DATA_DIR, 2, immunity_population, false),
-                IsSuccess());
-
+    {
+        mio::LogLevelOverride llo(mio::LogLevel::off);
+        ASSERT_THAT(mio::osecirts::read_input_data_county(model_vector, {2020, 12, 01}, {0},
+                                                          std::vector<double>(size_t(num_age_groups), 1.0), 1.0,
+                                                          TEST_DATA_DIR, 2, immunity_population, false),
+                    IsSuccess());
+    }
     // Values from data/export_time_series_init_osecirts.h5, for reading in comparison
     // operator for return of mio::read_result and model population needed.
     auto expected_values =

--- a/cpp/tests/test_odesecirts.cpp
+++ b/cpp/tests/test_odesecirts.cpp
@@ -35,7 +35,6 @@
 #include "memilio/utils/custom_index_array.h"
 #include "memilio/utils/parameter_distributions.h"
 #include "memilio/utils/parameter_set.h"
-#include "memilio/utils/random_number_generator.h"
 #include "memilio/utils/uncertain_value.h"
 #include "ode_secirts/infection_state.h"
 #include "ode_secirts/model.h"
@@ -48,7 +47,6 @@
 #include "gmock/gmock-matchers.h"
 #include <algorithm>
 #include <iterator>
-#include <limits>
 
 const mio::osecirts::Model<double>& osecirts_testing_model()
 {
@@ -141,7 +139,7 @@ TEST(TestOdeSECIRTS, get_flows)
 
 TEST(TestOdeSECIRTS, Simulation)
 {
-    auto sim        = mio::osecirts::Simulation<double>(osecirts_testing_model(), 0, 1);
+    auto sim = mio::osecirts::Simulation<double>(osecirts_testing_model(), 0, 1);
     sim.set_integrator_core(std::make_unique<mio::EulerIntegratorCore<double>>());
     sim.advance(1);
 
@@ -258,7 +256,8 @@ TEST(TestOdeSECIRTS, overflow_vaccinations)
     }
 
     // simulate one step with explicit Euler
-    auto result     = mio::simulate_flows<double, mio::osecirts::Model<double>>(t0, tmax, dt, model, std::make_unique<mio::EulerIntegratorCore<double>>());
+    auto result = mio::simulate_flows<double, mio::osecirts::Model<double>>(
+        t0, tmax, dt, model, std::make_unique<mio::EulerIntegratorCore<double>>());
 
     // get the flow indices for each type of vaccination and also the indices of the susceptible compartments
     auto flow_indx_partial_vaccination =
@@ -602,8 +601,6 @@ mio::osecirts::Model<double> make_model(int num_age_groups, bool set_invalid_ini
 
 TEST(TestOdeSECIRTS, draw_sample_graph)
 {
-    mio::log_thread_local_rng_seeds(mio::LogLevel::warn);
-
     mio::Graph<mio::osecirts::Model<double>, mio::MobilityParameters<double>> graph;
 
     auto num_age_groups = 6;
@@ -663,8 +660,6 @@ TEST(TestOdeSECIRTS, draw_sample_graph)
 
 TEST(TestOdeSECIRTS, draw_sample_model)
 {
-    mio::log_thread_local_rng_seeds(mio::LogLevel::warn);
-
     auto num_age_groups = 6;
     auto model          = make_model(num_age_groups, /*set_invalid_initial_value*/ true);
     mio::osecirts::draw_sample(model);
@@ -1159,8 +1154,6 @@ TEST(TestOdeSECIRTS, set_vaccination_data_min_date_not_avail)
 
 TEST(TestOdeSECIRTS, parameter_percentiles)
 {
-    mio::log_thread_local_rng_seeds(mio::LogLevel::warn);
-
     //build small graph
     auto model = make_model(5);
     auto graph = mio::Graph<mio::osecirts::Model<double>, mio::MobilityParameters<double>>();

--- a/cpp/tests/test_odesecirts.cpp
+++ b/cpp/tests/test_odesecirts.cpp
@@ -287,6 +287,7 @@ TEST(TestOdeSECIRTS, overflow_vaccinations)
 
 TEST(TestOdeSECIRTS, smooth_vaccination_rate)
 {
+    mio::LogLevelOverride llo(mio::LogLevel::off);
     const ScalarType tmax = 2.;
 
     // init simple model
@@ -708,6 +709,7 @@ TEST(TestOdeSECIRTS, checkPopulationConservation)
 
 TEST(TestOdeSECIRTS, read_confirmed_cases)
 {
+    mio::LogLevelOverride llo(mio::LogLevel::off);
     auto num_age_groups = 6; //reading data requires RKI data age groups
     auto model          = std::vector<mio::osecirts::Model<double>>({make_model(num_age_groups)});
     const std::vector<int> region{1002};
@@ -768,6 +770,7 @@ TEST(TestOdeSECIRTS, set_divi_data_invalid_dates)
 
 TEST(TestOdeSECIRTS, set_confirmed_cases_data_with_ICU)
 {
+    mio::LogLevelOverride llo(mio::LogLevel::off);
     const auto num_age_groups = 6;
     auto model                = mio::osecirts::Model<double>(num_age_groups);
     model.populations.array().setConstant(1);
@@ -837,6 +840,7 @@ TEST(TestOdeSECIRTS, set_confirmed_cases_data_with_ICU)
 
 TEST(TestOdeSECIRTS, read_data)
 {
+    mio::LogLevelOverride llo(mio::LogLevel::off);
     auto num_age_groups = 6; //reading data requires RKI data age groups
     auto model1         = std::vector<mio::osecirts::Model<double>>({make_model(num_age_groups)});
     auto model2         = std::vector<mio::osecirts::Model<double>>({make_model(num_age_groups)});
@@ -1071,6 +1075,7 @@ TEST(TestOdeSECIRTS, model_initialization)
 
 TEST(TestOdeSECIRTS, set_vaccination_data_not_avail)
 {
+    mio::LogLevelOverride llo(mio::LogLevel::off);
     const auto num_age_groups = 2;
     const auto num_days       = 5;
     mio::osecirts::Model<double> model(num_age_groups);

--- a/cpp/tests/test_odesecirvvs.cpp
+++ b/cpp/tests/test_odesecirvvs.cpp
@@ -429,8 +429,6 @@ mio::osecirvvs::Model<double> make_model(int num_age_groups, bool set_invalid_in
 
 TEST(TestOdeSECIRVVS, draw_sample)
 {
-    mio::log_thread_local_rng_seeds(mio::LogLevel::warn);
-
     mio::Graph<mio::osecirvvs::Model<double>, mio::MobilityParameters<double>> graph;
 
     auto num_age_groups = 6;
@@ -1169,8 +1167,6 @@ TEST(TestOdeSECIRVVS, set_vaccination_data_min_date_not_avail)
 
 TEST(TestOdeSECIRVVS, parameter_percentiles)
 {
-    mio::log_thread_local_rng_seeds(mio::LogLevel::warn);
-
     //build small graph
     auto model = make_model(5);
     auto graph = mio::Graph<mio::osecirvvs::Model<double>, mio::MobilityParameters<double>>();

--- a/cpp/tests/test_odesecirvvs.cpp
+++ b/cpp/tests/test_odesecirvvs.cpp
@@ -44,6 +44,7 @@
 #include "ode_secirvvs/parameters.h"
 #include "ode_secirvvs/parameters_io.h"
 #include "ode_secirvvs/analyze_result.h"
+#include "utils.h"
 
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
@@ -423,6 +424,7 @@ mio::osecirvvs::Model<double> make_model(int num_age_groups, bool set_invalid_in
     set_synthetic_population_data(model.populations, set_invalid_initial_value);
     set_demographic_parameters(model.parameters, set_invalid_initial_value);
     set_contact_parameters(model.parameters, set_invalid_initial_value);
+    mio::LogLevelOverride llo(mio::LogLevel::off);
     model.parameters.apply_constraints();
     return model;
 }

--- a/cpp/tests/test_odesecirvvs.cpp
+++ b/cpp/tests/test_odesecirvvs.cpp
@@ -589,6 +589,7 @@ TEST(TestOdeSECIRVVS, set_divi_data_invalid_dates)
 
 TEST(TestOdeSECIRVVS, set_confirmed_cases_data_with_ICU)
 {
+    mio::LogLevelOverride llo(mio::LogLevel::off);
     const auto num_age_groups = 6;
     auto model                = mio::osecirvvs::Model<double>(num_age_groups);
     model.populations.array().setConstant(1);
@@ -1001,6 +1002,7 @@ TEST(TestOdeSECIRVVS, model_initialization_old_date_county)
 
 TEST(TestOdeSECIRVVS, set_population_data_overflow_vacc)
 {
+    mio::LogLevelOverride llo(mio::LogLevel::off);
     auto num_age_groups = 6; // Data to be read requires RKI confirmed cases data age groups
     auto model          = make_model(num_age_groups);
     // set all compartments to zero
@@ -1040,6 +1042,7 @@ TEST(TestOdeSECIRVVS, set_population_data_overflow_vacc)
 
 TEST(TestOdeSECIRVVS, set_population_data_no_data_avail)
 {
+    mio::LogLevelOverride llo(mio::LogLevel::off);
     auto num_age_groups = 6; // Data to be read requires RKI confirmed cases data age groups
     auto model          = make_model(num_age_groups);
     // set all compartments to zero
@@ -1086,6 +1089,7 @@ TEST(TestOdeSECIRVVS, run_simulation)
 
 TEST(TestOdeSECIRVVS, set_vaccination_data_not_avail)
 {
+    mio::LogLevelOverride llo(mio::LogLevel::off);
     const auto num_age_groups = 2;
     const auto num_days       = 5;
     mio::osecirvvs::Model<double> model(num_age_groups);

--- a/cpp/tests/test_odeseirv.cpp
+++ b/cpp/tests/test_odeseirv.cpp
@@ -28,6 +28,7 @@
 #include "ode_seirv/model.h"
 #include "ode_seirv/infection_state.h"
 #include "ode_seirv/parameters.h"
+#include "utils.h"
 
 #include <gtest/gtest.h>
 
@@ -86,6 +87,7 @@ TEST(TestOdeSeirv, populationConservation)
 
 TEST(TestOdeSeirv, applyConstraints)
 {
+    mio::LogLevelOverride llo(mio::LogLevel::off); // hide contstraint warnings/errors
     mio::oseirv::Model<double> model(1);
     // First: defaults should need no correction
     EXPECT_FALSE(model.parameters.apply_constraints());
@@ -105,6 +107,7 @@ TEST(TestOdeSeirv, applyConstraints)
 
 TEST(TestOdeSeirv, checkConstraints)
 {
+    mio::LogLevelOverride llo(mio::LogLevel::off); // hide contstraint warnings/errors
     mio::oseirv::Model<double> model(1);
     EXPECT_FALSE(model.parameters.check_constraints());
 

--- a/cpp/tests/test_parameter_studies.cpp
+++ b/cpp/tests/test_parameter_studies.cpp
@@ -18,13 +18,13 @@
 * limitations under the License.
 */
 #include "memilio/config.h"
-#include "memilio/utils/miompi.h"
 #include "memilio/utils/parameter_distributions.h"
 #include "ode_secir/model.h"
 #include "ode_secir/parameter_space.h"
 #include "memilio/compartments/parameter_studies.h"
 #include "memilio/mobility/metapopulation_mobility_instant.h"
 #include "memilio/utils/random_number_generator.h"
+#include "utils.h"
 #include <cstddef>
 #include <gtest/gtest.h>
 #include <numeric>
@@ -32,8 +32,6 @@
 
 TEST(ParameterStudies, sample_from_secir_params)
 {
-    mio::log_thread_local_rng_seeds(mio::LogLevel::warn);
-
     double t0   = 0;
     double tmax = 100;
 
@@ -84,7 +82,10 @@ TEST(ParameterStudies, sample_from_secir_params)
 
     mio::osecir::set_params_distributions_normal(model, t0, tmax, 0.2);
 
-    draw_sample(model);
+    {
+        mio::LogLevelOverride llo(mio::LogLevel::off); // suppress draw sample warnings
+        draw_sample(model);
+    }
 
     for (auto i = mio::AgeGroup(0); i < params.get_num_groups(); i++) {
         ASSERT_EQ(params.get<mio::osecir::RelativeTransmissionNoSymptoms<double>>()[mio::AgeGroup(0)].value(),
@@ -162,8 +163,9 @@ TEST(ParameterStudies, sample_graph)
     graph.add_edge(0, 1, mio::MobilityParameters<double>(Eigen::VectorXd::Constant(Eigen::Index(num_groups * 8), 1.0)));
 
     mio::ParameterStudy study(graph, 0.0, 0.0, 0.5, 1);
-    mio::log_rng_seeds(study.get_rng(), mio::LogLevel::warn);
+
     auto ensemble_results = study.run_serial([](auto&& g, auto t0_, auto dt_, auto) {
+        mio::LogLevelOverride llo(mio::LogLevel::off); // suppress draw sample warnings
         auto copy = g;
         return mio::make_sampled_graph_simulation<double, mio::osecir::Simulation<ScalarType>>(draw_sample(copy), t0_,
                                                                                                dt_, dt_);
@@ -183,8 +185,6 @@ TEST(ParameterStudies, sample_graph)
 
 TEST(ParameterStudies, test_normal_distribution)
 {
-    mio::log_thread_local_rng_seeds(mio::LogLevel::warn);
-
     mio::ParameterDistributionNormal parameter_dist_normal_1;
 
     // check if standard deviation is reduced if between too narrow interval [min,max] has to be sampled.
@@ -231,8 +231,6 @@ TEST(ParameterStudies, test_normal_distribution)
 
 TEST(ParameterStudies, test_uniform_distribution)
 {
-    mio::log_thread_local_rng_seeds(mio::LogLevel::warn);
-
     // check if full argument constructor works correctly
     mio::ParameterDistributionUniform parameter_dist_unif(1.0, 10.0);
 
@@ -249,8 +247,6 @@ TEST(ParameterStudies, test_uniform_distribution)
 
 TEST(ParameterStudies, test_lognormal_distribution)
 {
-    mio::log_thread_local_rng_seeds(mio::LogLevel::warn);
-
     // check if full argument constructor works correctly
     mio::ParameterDistributionLogNormal parameter_dist_lognorm(0.0, 0.25);
 
@@ -260,8 +256,6 @@ TEST(ParameterStudies, test_lognormal_distribution)
 
 TEST(ParameterStudies, test_exponential_distribution)
 {
-    mio::log_thread_local_rng_seeds(mio::LogLevel::warn);
-
     // check if full argument constructor works correctly
     mio::ParameterDistributionExponential parameter_dist_exponential(1.);
 
@@ -270,8 +264,6 @@ TEST(ParameterStudies, test_exponential_distribution)
 
 TEST(ParameterStudies, test_constant_distribution)
 {
-    mio::log_thread_local_rng_seeds(mio::LogLevel::warn);
-
     // check if full argument constructor works correctly
     mio::ParameterDistributionConstant parameter_dist_constant(2.);
 
@@ -326,8 +318,6 @@ TEST(ParameterStudies, test_predefined_samples)
 
 TEST(ParameterStudies, check_ensemble_run_result)
 {
-    mio::log_thread_local_rng_seeds(mio::LogLevel::warn);
-
     double t0   = 0;
     double tmax = 50;
 

--- a/cpp/tests/test_save_results.cpp
+++ b/cpp/tests/test_save_results.cpp
@@ -27,6 +27,7 @@
 #include "memilio/utils/time_series.h"
 #include "ode_secir/parameter_space.h"
 #include "ode_secir/parameters_io.h"
+#include "utils.h"
 #include <gtest/gtest.h>
 #include <string>
 
@@ -229,12 +230,11 @@ TEST(TestSaveResult, save_result_with_params)
 
 TEST(TestSaveResult, save_result_order)
 {
-    std::vector<mio::TimeSeries<double>> results{
-        mio::TimeSeries<double>(0, Eigen::VectorX<double>::Constant(1, 0)), 
-        mio::TimeSeries<double>(0, Eigen::VectorX<double>::Constant(1, 1)), 
-        mio::TimeSeries<double>(0, Eigen::VectorX<double>::Constant(1, 2))};
+    std::vector<mio::TimeSeries<double>> results{mio::TimeSeries<double>(0, Eigen::VectorX<double>::Constant(1, 0)),
+                                                 mio::TimeSeries<double>(0, Eigen::VectorX<double>::Constant(1, 1)),
+                                                 mio::TimeSeries<double>(0, Eigen::VectorX<double>::Constant(1, 2))};
 
-    // case: check order of results, where lexical ordering would rearrange the results; 
+    // case: check order of results, where lexical ordering would rearrange the results;
     // expect: order follows the ids
     std::vector<int> ids = {1, 2, 10};
 
@@ -250,7 +250,7 @@ TEST(TestSaveResult, save_result_order)
     ASSERT_DOUBLE_EQ(results_from_file.value()[1].get_groups()[Eigen::Index(0)][Eigen::Index(0)], 1);
     ASSERT_DOUBLE_EQ(results_from_file.value()[2].get_groups()[Eigen::Index(0)][Eigen::Index(0)], 2);
 
-    // case: check order of results; 
+    // case: check order of results;
     // expect: order is changed due to ids not increasing
     ids = {1, 10, 2};
 
@@ -346,7 +346,6 @@ TEST(TestSaveResult, save_percentiles_and_sums)
 
     auto num_runs = 3;
     mio::ParameterStudy parameter_study(graph, 0.0, 2.0, 0.5, num_runs);
-    mio::log_rng_seeds(parameter_study.get_rng(), mio::LogLevel::warn);
 
     TempFileRegister tmp_file_register;
     std::string tmp_results_dir = tmp_file_register.get_unique_path();
@@ -360,6 +359,7 @@ TEST(TestSaveResult, save_percentiles_and_sums)
     ensemble_edges.reserve(size_t(num_runs));
     parameter_study.run(
         [](auto&& g, auto t0_, auto dt_, auto) {
+            mio::LogLevelOverride llo(mio::LogLevel::off);
             auto copy = g;
             return mio::make_sampled_graph_simulation<double, mio::osecir::Simulation<double>>(draw_sample(copy), t0_,
                                                                                                dt_, dt_);

--- a/cpp/tests/test_time_series.cpp
+++ b/cpp/tests/test_time_series.cpp
@@ -362,7 +362,9 @@ TYPED_TEST(TestTimeSeries, print_table_cout_overload)
     // Just test that the print_table overload without ostream argument doesn't throw any exceptions.
     // The function behaviour is tested in "TestTimeSeries.print_table".
     mio::TimeSeries<TypeParam> ts = mio::TimeSeries<TypeParam>::zero(1, 1);
+    std::cout.setstate(std::ios_base::failbit);
     ASSERT_NO_FATAL_FAILURE(ts.print_table());
+    std::cout.clear();
 }
 
 TYPED_TEST(TestTimeSeries, export_csv)

--- a/cpp/tests/test_uncertain.cpp
+++ b/cpp/tests/test_uncertain.cpp
@@ -95,8 +95,6 @@ TEST(TestUncertain, uncertain_value_assign)
 
 TEST(TestUncertain, uncertain_value_predef)
 {
-    mio::log_thread_local_rng_seeds(mio::LogLevel::warn);
-
     mio::UncertainValue<double> val(3.0);
     double dev_rel     = 0.2;
     double lower_bound = std::max(1e-6, (1 - dev_rel * 2.6) * val);
@@ -117,8 +115,6 @@ TEST(TestUncertain, uncertain_value_predef)
 
 TEST(TestUncertain, uncertain_matrix)
 {
-    mio::log_thread_local_rng_seeds(mio::LogLevel::warn);
-
     mio::ContactMatrix<double> contact_matrix(Eigen::MatrixXd::NullaryExpr(2, 2, [](auto i, auto j) -> double {
         return (i + 1) * (j + 1);
     }));

--- a/cpp/tests/test_utils.cpp
+++ b/cpp/tests/test_utils.cpp
@@ -171,7 +171,7 @@ TEST(TestUtils, LogLevelOverride)
     logger.capture();
     // sanity check that the capture works (ignoring the time stamp at the start)
     mio::log_warning("Test0");
-    EXPECT_THAT(logger.read(), testing::EndsWith("[redirect] [warning] Test0\n"));
+    EXPECT_THAT(logger.read(), testing::HasSubstr("[redirect] [warning] Test0"));
     // case: override to higher level, log at normal level; expect a usually emitted log to be ignored
     {
         mio::LogLevelOverride llo(mio::LogLevel::critical);
@@ -180,13 +180,13 @@ TEST(TestUtils, LogLevelOverride)
     EXPECT_TRUE(logger.read().empty());
     // case: log at normal level, after higher level override; expect normal logging
     mio::log_warning("Test2");
-    EXPECT_THAT(logger.read(), testing::EndsWith("[redirect] [warning] Test2\n"));
+    EXPECT_THAT(logger.read(), testing::HasSubstr("[redirect] [warning] Test2"));
     // case: override to lower level, log at a level below normal; expect a usually ignored log to be emitted
     {
         mio::LogLevelOverride llo(mio::LogLevel::info);
         mio::log_info("Test3");
     }
-    EXPECT_THAT(logger.read(), testing::EndsWith("[redirect] [info] Test3\n"));
+    EXPECT_THAT(logger.read(), testing::HasSubstr("[redirect] [info] Test3"));
 
     logger.release();
 }

--- a/cpp/tests/test_utils.cpp
+++ b/cpp/tests/test_utils.cpp
@@ -164,6 +164,33 @@ TEST(TestUtils, RedirectLogger)
     logger.release();
 }
 
+TEST(TestUtils, LogLevelOverride)
+{
+    // test that LogLevelOverride behaves as intended
+    mio::RedirectLogger logger;
+    logger.capture();
+    // sanity check that the capture works (ignoring the time stamp at the start)
+    mio::log_warning("Test0");
+    EXPECT_THAT(logger.read(), testing::EndsWith("[redirect] [warning] Test0\n"));
+    // case: override to higher level, log at normal level; expect a usually emitted log to be ignored
+    {
+        mio::LogLevelOverride llo(mio::LogLevel::critical);
+        mio::log_warning("Test1");
+    }
+    EXPECT_TRUE(logger.read().empty());
+    // case: log at normal level, after higher level override; expect normal logging
+    mio::log_warning("Test2");
+    EXPECT_THAT(logger.read(), testing::EndsWith("[redirect] [warning] Test2\n"));
+    // case: override to lower level, log at a level below normal; expect a usually ignored log to be emitted
+    {
+        mio::LogLevelOverride llo(mio::LogLevel::info);
+        mio::log_info("Test3");
+    }
+    EXPECT_THAT(logger.read(), testing::EndsWith("[redirect] [info] Test3\n"));
+
+    logger.release();
+}
+
 TEST(TestUtils, base_dir)
 {
     auto base_dir = boost::filesystem::path(mio::base_dir());

--- a/cpp/tests/testmain.cpp
+++ b/cpp/tests/testmain.cpp
@@ -25,9 +25,19 @@
 int main(int argc, char** argv)
 {
     mio::mpi::init();
-    mio::set_log_level(mio::LogLevel::warn);
+    mio::set_log_level(mio::LogLevel::info); // only used for logging testing environment info
+    mio::log_thread_local_rng_seeds(mio::LogLevel::info);
 
+#ifndef NDEBUG
+    // in debug builds:
+    // suppress output from successful tests, so output from failures is easy to find
+    GTEST_FLAG_SET(brief, true);
+    // shuffle order of tests, to make sure they are not interdependant
+    GTEST_FLAG_SET(shuffle, true);
+#endif
     ::testing::InitGoogleTest(&argc, argv);
+
+    mio::set_log_level(mio::LogLevel::warn); // main log level for testing
     int retval = RUN_ALL_TESTS();
     mio::mpi::finalize();
     return retval;

--- a/cpp/tests/testmain.cpp
+++ b/cpp/tests/testmain.cpp
@@ -30,9 +30,11 @@ int main(int argc, char** argv)
 
 #ifndef NDEBUG
     // in debug builds:
-    // suppress output from successful tests, so output from failures is easy to find
+    // change the default values of the following gtest flags
+    // the flags can still be set through CLI arguments, which are processed by InitGoogleTest below
+    // - brief: suppress status output from successful tests, so output from failures is easy to find
     GTEST_FLAG_SET(brief, true);
-    // shuffle order of tests, to make sure they are not interdependant
+    // - shuffle: randomly change order of tests, to make sure they are not interdependant
     GTEST_FLAG_SET(shuffle, true);
 #endif
     ::testing::InitGoogleTest(&argc, argv);
@@ -42,3 +44,4 @@ int main(int argc, char** argv)
     mio::mpi::finalize();
     return retval;
 }
+

--- a/cpp/tests/utils.h
+++ b/cpp/tests/utils.h
@@ -31,6 +31,25 @@
 namespace mio
 {
 
+/// @brief Sets the default log level on creation, and resets it to the previous level on destruction.
+class LogLevelOverride
+{
+public:
+    LogLevelOverride(LogLevel temporary_level)
+        : m_previous_level(spdlog::default_logger()->level())
+    {
+        set_log_level(temporary_level);
+    }
+
+    ~LogLevelOverride()
+    {
+        spdlog::set_level(m_previous_level);
+    }
+
+private:
+    spdlog::level::level_enum m_previous_level;
+};
+
 /// @brief Can be used to redirect an spdlog::logger. This may cause unintended side effects, like silencing errors!
 class RedirectLogger
 {


### PR DESCRIPTION
# Changes and Information

Please **briefly list the changes** (main added features, changed items, or corrected bugs) made:

- Set gtest flags "brief" and "shuffle" in debug builds.
- Add LogLevelOverride to temporarily  change log levels.
- Make RandomNumberTest use the same seed as thread_local_rng instead getting a new one each test, but still reset the counter.
- Only log rng seeds once.
- Turn off several unneeded log outputs.

If need be, add additional information and what the reviewer should look out for in particular:

- ~Tests that currently still emit logs:~
  - ~TestOdeSECIRTS.smooth_vaccination_rate~
  - ~TestOdeSECIRTS.read_data~
  - ~TestOdeSECIRTS.read_confirmed_cases~
  - ~TestOdeSECIRTS.set_vaccination_data_not_avail~
  - ~TestOdeSECIRTS.set_confirmed_cases_data_with_ICU~
  - ~ModelTestOdeSecir.set_confirmed_cases_data_with_ICU~
  - ~TestOdeSECIRVVS.set_population_data_overflow_vacc~
  - ~TestOdeSECIRVVS.set_vaccination_data_not_avail~
  - ~TestOdeSECIRVVS.set_population_data_no_data_avail~
  - ~TestOdeSECIRVVS.set_confirmed_cases_data_with_ICU~

## Merge Request - Guideline Checklist

Please check our [git workflow](https://memilio.readthedocs.io/en/latest/development.html#git-workflow). Use the **draft** feature if the Pull Request is not yet ready to review.

### Checks by code author

- [x] Every addressed issue is linked (use the "Closes #ISSUE" keyword below)
- [x] New code adheres to [coding guidelines](https://memilio.readthedocs.io/en/latest/development.html#coding-guidelines)
- [x] No large data files have been added (files should in sum not exceed 100 KB, avoid PDFs, Word docs, etc.)
- [x] Tests are added for new functionality and a local test run was successful (with and without OpenMP)
- [x] Appropriate **documentation within the code** (Doxygen) for new functionality has been added in the code
- [x] Appropriate **external documentation** (ReadTheDocs) for new functionality has been added to the online documentation
- [x] Proper attention to licenses, especially no new third-party software with conflicting license has been added
- [ ] (For ABM development) Checked [benchmark results](https://memilio.readthedocs.io/en/latest/development.html#agent-based-model-development) and ran and posted a local test above from before and after development to ensure performance is monitored.

### Checks by code reviewer(s)

- [x] Corresponding issue(s) is/are linked and addressed
- [x] Code is clean of development artifacts (no deactivated or commented code lines, no debugging printouts, etc.)
- [x] Appropriate **unit tests** have been added, CI passes, code coverage and performance is acceptable (did not decrease)
- [x] No large data files added in the whole history of commits(files should in sum not exceed 100 KB, avoid PDFs, Word docs, etc.)
- [ ] On merge, add 2-5 lines with the changes (main added features, changed items, or corrected bugs) to the merge-commit-message. This can be taken from the **briefly-list-the-changes** above (best case) or the separate commit messages (worst case).

Closes #1463