### PR TITLE
1496 smm model output is misaligned with time points

### DIFF
--- a/cpp/models/smm/simulation.h
+++ b/cpp/models/smm/simulation.h
@@ -83,10 +83,11 @@ public:
         update_current_rates_and_waiting_times();
         size_t next_event = determine_next_event(); // index of the next event
         FP current_time   = m_result.get_last_time();
-        // set in the past to add a new time point immediately
+        // set current time to add next time point in the future
         FP last_result_time = current_time;
         // iterate over time
         while (current_time + m_waiting_times[next_event] < tmax) {
+            // If the next event happens further in the future than the next stored time point, add a new one.
             if (current_time + m_waiting_times[next_event] >= last_result_time) {
                 auto num_dt      = std::ceil((current_time + m_waiting_times[next_event] - last_result_time) / m_dt);
                 last_result_time = std::min(tmax, last_result_time + num_dt * m_dt);


### PR DESCRIPTION
# Changes and Information

Please **briefly list the changes** (main added features, changed items, or corrected bugs) made:

- The SMM advance function first creates a vector for the last possible saving time step, then it operates on this vector and thus stores all changes from $t$ to $t + \epsilon$ at $t+\epsilon$ instead of $t$.

If need be, add additional information and what the reviewer should look out for in particular:


## Merge Request - Guideline Checklist

Please check our [git workflow](https://memilio.readthedocs.io/en/latest/development.html#git-workflow). Use the **draft** feature if the Pull Request is not yet ready to review.

### Checks by code author

- [x] Every addressed issue is linked (use the "Closes #ISSUE" keyword below)
- [x] New code adheres to [coding guidelines](https://memilio.readthedocs.io/en/latest/development.html#coding-guidelines)
- [x] No large data files have been added (files should in sum not exceed 100 KB, avoid PDFs, Word docs, etc.)
- [ ] Tests are added for new functionality and a local test run was successful (with and without OpenMP)
- [x] Appropriate **documentation within the code** (Doxygen) for new functionality has been added in the code
- [x] Appropriate **external documentation** (ReadTheDocs) for new functionality has been added to the online documentation
- [x] Proper attention to licenses, especially no new third-party software with conflicting license has been added
- [ ] (For ABM development) Checked [benchmark results](https://memilio.readthedocs.io/en/latest/development.html#agent-based-model-development) and ran and posted a local test above from before and after development to ensure performance is monitored.

### Checks by code reviewer(s)

- [x] Corresponding issue(s) is/are linked and addressed
- [x] Code is clean of development artifacts (no deactivated or commented code lines, no debugging printouts, etc.)
- [x] Appropriate **unit tests** have been added, CI passes, code coverage and performance is acceptable (did not decrease)
- [x] No large data files added in the whole history of commits(files should in sum not exceed 100 KB, avoid PDFs, Word docs, etc.)
- [ ] On merge, add 2-5 lines with the changes (main added features, changed items, or corrected bugs) to the merge-commit-message. This can be taken from the **briefly-list-the-changes** above (best case) or the separate commit messages (worst case).

Closes #1496 