### PR TITLE
1570 Allow setting tolerance for last timestep in SystemIntegrator manually

### DIFF
--- a/cpp/memilio/compartments/simulation_base.h
+++ b/cpp/memilio/compartments/simulation_base.h
@@ -154,6 +154,31 @@ public:
     }
     /** @} */
 
+    /**
+     * @brief Change the tolerance for the last time step.
+     * @param last_step_tolerance The new last_step_tolerance.
+     */
+    void set_last_step_tolerance(FP new_tol)
+    {
+        m_integrator.set_last_step_tolerance(new_tol);
+    }
+
+    /**
+     * @brief Access the tolerance for the last time step.
+     * @return A reference to the last_step_tolerance.
+     * @{
+     */
+    FP& get_last_step_tolerance()
+    {
+        return m_integrator.get_last_step_tolerance();
+    }
+
+    const FP& get_last_step_tolerance() const
+    {
+        return m_integrator.get_last_step_tolerance();
+    }
+    /** @} */
+
 protected:
     /**
      * @brief Run the simulation up to a given time.

--- a/cpp/memilio/math/integrator.h
+++ b/cpp/memilio/math/integrator.h
@@ -60,7 +60,7 @@ public:
     {
     }
 
-    virtual ~IntegratorCore() {};
+    virtual ~IntegratorCore(){};
 
     virtual std::unique_ptr<IntegratorCore<FP, Integrands...>> clone() const = 0;
 
@@ -188,8 +188,7 @@ public:
         using std::fabs;
         using std::max;
         using std::min;
-        const FP t0  = results.get_last_time();
-        const FP eps = Limits<FP>::zero_tolerance();
+        const FP t0 = results.get_last_time();
         assert(tmax > t0);
         assert(dt > 0);
 
@@ -205,7 +204,8 @@ public:
         FP dt_min_restore = m_core->get_dt_min(); // used to restore dt_min, if it was decreased to reach tmax
         FP t              = t0;
 
-        for (size_t i = results.get_num_time_points() - 1; fabs((tmax - t) / (tmax - t0)) > eps; ++i) {
+        for (size_t i = results.get_num_time_points() - 1; fabs((tmax - t) / (tmax - t0)) > m_last_step_tolerance;
+             ++i) {
             // We don't make time steps too small as the error estimator of an adaptive integrator
             //may not be able to handle it. this is very conservative and maybe unnecessary,
             //but also unlikely to happen. may need to be reevaluated.
@@ -226,7 +226,7 @@ public:
             results.get_last_time() = t;
 
             // if dt has been changed by step, register the current m_core as adaptive.
-            m_is_adaptive |= !floating_point_equal<FP>(dt, dt_copy, eps);
+            m_is_adaptive |= !floating_point_equal<FP>(dt, dt_copy, Limits<FP>::zero_tolerance());
         }
         m_core->get_dt_min() = dt_min_restore; // restore dt_min
         // if dt was decreased to reach tmax in the last time iteration,
@@ -237,7 +237,7 @@ public:
             if (!step_okay) {
                 log_warning("Adaptive step sizing failed. Forcing an integration step of size dt_min.");
             }
-            else if (fabs((tmax - t) / (tmax - t0)) > eps) {
+            else if (fabs((tmax - t) / (tmax - t0)) > m_last_step_tolerance) {
                 log_warning("Last time step too small. Could not reach tmax exactly.");
             }
             else {
@@ -271,10 +271,37 @@ public:
     {
         return *m_core;
     }
+    /** @} */
+
+    /**
+     * @brief Change the tolerance for the last time step.
+     * @param last_step_tolerance The new last_step_tolerance.
+     */
+    void set_last_step_tolerance(FP last_step_tolerance)
+    {
+        m_last_step_tolerance = last_step_tolerance;
+    }
+
+    /**
+     * @brief Access the tolerance for the last time step.
+     * @return A reference to the last_step_tolerance.
+     * @{
+     */
+    FP& get_last_step_tolerance()
+    {
+        return m_last_step_tolerance;
+    }
+
+    const FP& get_last_step_tolerance() const
+    {
+        return m_last_step_tolerance;
+    }
+    /** @} */
 
 private:
     std::unique_ptr<Core> m_core;
     bool m_is_adaptive;
+    FP m_last_step_tolerance = Limits<FP>::zero_tolerance();
 };
 
 /**

--- a/cpp/tests/test_compartments_simulation.cpp
+++ b/cpp/tests/test_compartments_simulation.cpp
@@ -90,6 +90,18 @@ TEST(TestCompartmentSimulation, copy_simulation)
     EXPECT_EQ(sim.get_integrator_core().get_dt_max(), sim_copy_assign.get_integrator_core().get_dt_max());
 }
 
+TEST(TestCompartmentSimulation, last_step_tolerance)
+{
+    auto sim = mio::Simulation<double, MockModel>(MockModel(), 0.0);
+
+    // Check default.
+    EXPECT_EQ(sim.get_last_step_tolerance(), mio::Limits<double>::zero_tolerance());
+    // Check setter of tolerance.
+    auto new_tol = 1e-2;
+    sim.set_last_step_tolerance(new_tol);
+    EXPECT_EQ(sim.get_last_step_tolerance(), new_tol);
+}
+
 struct MockSimulateSim { // looks just enough like a simulation for the simulate functions not to notice
 
     // this "model" converts to and from int implicitly, exposing its value after calling chech_constraints

--- a/cpp/tests/test_numericalIntegration.cpp
+++ b/cpp/tests/test_numericalIntegration.cpp
@@ -406,6 +406,20 @@ TEST(TestOdeIntegrator, integratorForcesLastStepSize)
     }
 }
 
+TEST(TestOdeIntegrator, integratorLastStepTolerance)
+{
+    using testing::_;
+    auto mock_core = std::make_unique<testing::StrictMock<MockIntegratorCore>>();
+
+    auto integrator = mio::OdeIntegrator<double>(std::move(mock_core));
+    // Check default.
+    EXPECT_EQ(integrator.get_last_step_tolerance(), mio::Limits<double>::zero_tolerance());
+    // Check setter of tolerance.
+    auto new_tol = 1e-2;
+    integrator.set_last_step_tolerance(new_tol);
+    EXPECT_EQ(integrator.get_last_step_tolerance(), new_tol);
+}
+
 TEST(TestStochasticIntegrator, EulerMaruyamaIntegratorCore)
 {
     using X = Eigen::Vector2d;


### PR DESCRIPTION
# Changes and Information

- Add setter and getter for last_step_tolerance that determines if an additional time step is made to reach tmax

## Merge Request - Guideline Checklist

Please check our [git workflow](https://memilio.readthedocs.io/en/latest/development.html#git-workflow). Use the **draft** feature if the Pull Request is not yet ready to review.

### Checks by code author

- [x] Every addressed issue is linked (use the "Closes #ISSUE" keyword below).
- [x] New code adheres to [coding guidelines](https://memilio.readthedocs.io/en/latest/development.html#coding-guidelines).
- [x] No large data files have been added (files should in sum not exceed 100 KB, avoid PDFs, Word docs, etc.).
- [x] Tests are added for new functionality and a local test run was successful (with and without OpenMP).
- [x] Appropriate **documentation within the code** (Doxygen) for new functionality has been added in the code.
- [x] Appropriate **external documentation** (ReadTheDocs) for new functionality has been added to the online documentation and checked in the preview.
- [x] Proper attention to licenses, especially no new third-party software with conflicting license has been added.
- [ ] (For ABM development) Checked [benchmark results](https://memilio.readthedocs.io/en/latest/development.html#agent-based-model-development) and ran and posted a local test above from before and after development to ensure performance is monitored.

### Checks by code reviewer(s)

- [x] Corresponding issue(s) is/are linked and addressed.
- [ ] Code is clean of development artifacts (no deactivated or commented code lines, no debugging printouts, etc.).
- [ ] Appropriate **unit tests** have been added, CI passes, code coverage and performance is acceptable (did not decrease).
- [x] No large data files added in the whole history of commits(files should in sum not exceed 100 KB, avoid PDFs, Word docs, etc.).
- [ ] On merge, add 2-5 lines with the changes (main added features, changed items, or corrected bugs) to the merge-commit-message. This can be taken from the **briefly-list-the-changes** above (best case) or the separate commit messages (worst case).

Closes #1570 