### PR TITLE
1580 Reuse flow difference vector

### DIFF
--- a/cpp/memilio/compartments/flow_simulation.h
+++ b/cpp/memilio/compartments/flow_simulation.h
@@ -75,8 +75,9 @@ public:
                 //   To incorporate external changes to the last values of pop_result (e.g. by applying mobility), we only
                 //   calculate the change in population starting from the last available time point in m_result, instead
                 //   of starting at t0. To do that, the following difference of flows is used.
-                model.get_derivatives(flows - Base::get_flows().get_value(pop_result.get_num_time_points() - 1),
-                                      m_pop); // note: overwrites values in pop
+                auto& flow_delta = Base::get_flow_delta();
+                flow_delta       = flows - Base::get_flows().get_value(pop_result.get_num_time_points() - 1);
+                model.get_derivatives(flow_delta, m_pop); // note: overwrites values in pop
                 //   add the "initial" value of the ODEs (using last available time point in pop_result)
                 //     If no changes were made to the last value in m_result outside of FlowSimulation, the following
                 //     line computes the same as `model.get_derivatives(flows, x); x += model.get_initial_values();`.

--- a/cpp/memilio/compartments/flow_simulation_base.h
+++ b/cpp/memilio/compartments/flow_simulation_base.h
@@ -95,6 +95,7 @@ protected:
         auto& result      = this->get_result();
         // take the last time point as base result (instead of the initial results), so that we use external changes
         const size_t last_tp = result.get_num_time_points() - 1;
+        result.reserve(flows.get_num_time_points());
         // calculate new time points
         for (Eigen::Index i = result.get_num_time_points(); i < flows.get_num_time_points(); i++) {
             result.add_time_point(flows.get_time(i));

--- a/cpp/memilio/compartments/flow_simulation_base.h
+++ b/cpp/memilio/compartments/flow_simulation_base.h
@@ -56,6 +56,7 @@ public:
     FlowSimulationBase(Model const& model, std::unique_ptr<Core>&& integrator_core, FP t0, FP dt)
         : Base(model, std::move(integrator_core), t0, dt)
         , m_flow_result(t0, model.get_initial_flows())
+        , m_flow_delta(model.get_initial_flows().size())
     {
     }
 
@@ -97,13 +98,20 @@ protected:
         // calculate new time points
         for (Eigen::Index i = result.get_num_time_points(); i < flows.get_num_time_points(); i++) {
             result.add_time_point(flows.get_time(i));
-            model.get_derivatives(flows.get_value(i) - flows.get_value(last_tp), result.get_value(i));
+            m_flow_delta = flows.get_value(i) - flows.get_value(last_tp);
+            model.get_derivatives(m_flow_delta, result.get_value(i));
             result.get_value(i) += result.get_value(last_tp);
         }
     }
 
+    Eigen::VectorX<FP>& get_flow_delta()
+    {
+        return m_flow_delta;
+    }
+
 private:
     mio::TimeSeries<FP> m_flow_result; ///< Flow result of the simulation.
+    Eigen::VectorX<FP> m_flow_delta; ///< Pre-allocated temporary for flow changes relative to the current base point.
 };
 
 /// @brief Specialization of FlowSimulationBase that takes a SystemIntegrator instead of it's Integrands.


### PR DESCRIPTION
# Changes and Information

Please **briefly list the changes** (main added features, changed items, or corrected bugs) made:

- reusable flow-difference vector is allocated once per simulation 
- and used for both right-hand-side evaluations and compartment reconstruction


If need be, add additional information and what the reviewer should look out for in particular:

-
-

## Merge Request - Guideline Checklist

Please check our [git workflow](https://memilio.readthedocs.io/en/latest/development.html#git-workflow). Use the **draft** feature if the Pull Request is not yet ready to review.

### Checks by code author

- [x] Every addressed issue is linked (use the "Closes #ISSUE" keyword below).
- [x] New code adheres to [coding guidelines](https://memilio.readthedocs.io/en/latest/development.html#coding-guidelines).
- [x] No large data files have been added (files should in sum not exceed 100 KB, avoid PDFs, Word docs, etc.).
- [x] Tests are added for new functionality and a local test run was successful (with and without OpenMP).
- [x] Appropriate **documentation within the code** (Doxygen) for new functionality has been added in the code.
- [x] Appropriate **external documentation** (ReadTheDocs) for new functionality has been added to the online documentation and checked in the preview.
- [x] Proper attention to licenses, especially no new third-party software with conflicting license has been added.
- [ ] (For ABM development) Checked [benchmark results](https://memilio.readthedocs.io/en/latest/development.html#agent-based-model-development) and ran and posted a local test above from before and after development to ensure performance is monitored.

### Checks by code reviewer(s)

- [x] Corresponding issue(s) is/are linked and addressed.
- [ ] Code is clean of development artifacts (no deactivated or commented code lines, no debugging printouts, etc.).
- [ ] Appropriate **unit tests** have been added, CI passes, code coverage and performance is acceptable (did not decrease).
- [ ] No large data files added in the whole history of commits(files should in sum not exceed 100 KB, avoid PDFs, Word docs, etc.).
- [ ] On merge, add 2-5 lines with the changes (main added features, changed items, or corrected bugs) to the merge-commit-message. This can be taken from the **briefly-list-the-changes** above (best case) or the separate commit messages (worst case).
